### PR TITLE
Gameplay redesign: three role-based modes with true information hiding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,9 +112,16 @@ Gameplay is split into three roles, each seeing only what it should:
   `visibility.js` for a same-device demo). Enforce new features this way.
 - **Model support:** combatants carry a `hidden` flag (`DM.setHidden`,
   serialized). The battlemap carries fog of war (`map.fog`, `map.revealed`
-  cells) + per-area `hidden`/`revealed`, with `Battlemap.setFog/revealCell/
-  revealAround/revealAll/clearRevealed/revealArea`. The DM console's "👁 Players
-  see" panel + the per-creature 👁/🙈 toggle drive these and re-publish.
+  cells) + per-area `hidden`/`revealed` + **markers** (`map.markers`:
+  trap/secret/treasure point entities, DM-only until `revealed`, with a secret
+  `note`). API: `Battlemap.setFog/revealCell/revealAround/revealAll/
+  clearRevealed/revealArea/setAutoReveal` and `setMarkerType/getMarkers/
+  revealMarker/removeMarker`. The DM paints reveal/hide with a **fog brush**
+  (the `reveal`/`hide`/`marker` tools work in `play` mode too), fog **auto-
+  reveals around player tokens** as they move (`setAutoReveal`), and the "👁
+  Players see" panel + per-creature 👁/🙈 toggle drive it all and re-publish.
+  `visibility.js` drops unrevealed markers/areas/cells and every DM `note`
+  before the projection leaves the DM's seat.
 
 ### AI layer (Play page)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,13 +193,19 @@ shape used for local autosave **and** cloud `play_sessions.state`.
 
 - Schema in `supabase/schema.sql` (run once in the SQL Editor). Tables:
   `profiles`, `groups`, `group_members`, `character_sheets` (legacy, unused by
-  the frontend), `play_sessions` (live game state + Realtime), `user_collections`
-  (characters/adventures/encounters blobs). RLS throughout; owner-writes /
-  group-members-read for shared sessions.
+  the frontend), `play_sessions` (full DM state — **owner-only**),
+  `play_player_views` (the sanitized projection players read — group-readable),
+  `user_collections` (characters/adventures/encounters blobs). RLS throughout.
 - Setup steps and the new-dashboard locations for URL + key are in `SUPABASE.md`.
-- **Sharing model:** single-writer. The DM owns and writes a `play_sessions` row;
-  when `shared=true` + attached to a group, group members open it read-only and
-  get live Realtime updates (~2s cadence, the cloud-autosave debounce).
+- **Sharing model:** single-writer, **two rows per live session**. The DM owns
+  and writes the full `play_sessions.state` (owner-only RLS — players can't read
+  it). When sharing to a group, the DM also upserts `play_player_views.view` =
+  `Visibility.playerView(snapshot)`; group members read/subscribe to *that* row
+  only (Realtime, ~2s cadence). This is the multiplayer half of the fundamental
+  rule: because Postgres RLS can't hide a single column, the hidden state and the
+  player projection are **separate tables**, and player clients never touch the
+  full-state table. Players join via the group invite code and open the DM's
+  `player.html?s=<sessionId>` link (a lobby in `player.js`).
 
 ## Running & testing locally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,36 @@ Supabase cloud sync.
     the top. In `adventures-data.js`, `bmap()` reads `P`/`M`/`N` ASCII markers
     or takes an explicit `starts` 4th arg (for starts that sit on water/terrain).
 
+### Role-based visibility (three play modes)
+
+Gameplay is split into three roles, each seeing only what it should:
+
+- **Play vs AI DM** (`play-ai.html` → `play.html?role=ai`) — single-player; the
+  AI is the DM (sees all via `ai-context.js`, which already hides player HP).
+- **DM Console** (`dm.html` → `play.html?role=dm`) — a human DM; same game
+  session as AI mode with the AI panel hidden. Both share `play.js`.
+- **Player** (`player.html` + `player.js`) — the separate player client.
+
+- **`visibility.js` → `window.Visibility`** — pure, the **keystone**.
+  `playerView(snapshot, opts)` returns a snapshot containing ONLY what a player
+  may know: revealed combatants (hidden ones removed), revealed non-secret map
+  areas (DM notes stripped), the fog-limited map (unrevealed terrain + the
+  background image not included), the player's own token, and DM narration. It
+  drops the raw combat log, the AI transcript, monster statistics (HP/AC/attacks
+  → a coarse `health` band only), start zones and DM notes.
+- **FUNDAMENTAL RULE:** hidden info is never *sent* to a player client and then
+  hidden in the UI — it must not leave the DM's seat. The DM side computes the
+  player projection (`Visibility.playerView`) and publishes only that
+  (`localStorage 'diceAndMonsters.playerProjection'` now; a player-readable
+  Supabase column later — never the full `state` blob). `player.js` consumes
+  only that projection (falling back to projecting the local autosave *through*
+  `visibility.js` for a same-device demo). Enforce new features this way.
+- **Model support:** combatants carry a `hidden` flag (`DM.setHidden`,
+  serialized). The battlemap carries fog of war (`map.fog`, `map.revealed`
+  cells) + per-area `hidden`/`revealed`, with `Battlemap.setFog/revealCell/
+  revealAround/revealAll/clearRevealed/revealArea`. The DM console's "👁 Players
+  see" panel + the per-creature 👁/🙈 toggle drive these and re-publish.
+
 ### AI layer (Play page)
 
 - **`ai-context.js` → `window.AIContext.build(state, opts)`** — pure. Serializes

--- a/SUPABASE.md
+++ b/SUPABASE.md
@@ -14,6 +14,10 @@ Supabase's free tier, with no server to run yourself.
   - A **group** is a play party. Anyone with the invite code can join.
   - A sheet attached to a group and marked **shared** is readable by
     every member of that group (DM included).
+  - A **live session's full state is owner-only** (it holds hidden
+    monsters, DM notes and traps). When a DM shares a session, players
+    read a *separate* `play_player_views` row that contains only the
+    sanitized projection — hidden info never reaches a player client.
 - The site keeps working offline via `localStorage`; when you're
   signed in, data syncs to the cloud too.
 
@@ -25,7 +29,9 @@ Supabase's free tier, with no server to run yourself.
 2. Open **SQL Editor** → **New query**, paste the whole contents of
    [`supabase/schema.sql`](supabase/schema.sql), and click **Run**.
    This creates the tables, the sharing rules, and the join/group
-   helper functions.
+   helper functions. (Re-run it after updating the app — it's
+   idempotent — to add the `play_player_views` table and tighten the
+   session policy for the live-multiplayer split.)
 3. Open **Authentication → Providers** and enable **Email** (and
    optionally **Google** for one-click login).
 4. Open **Project Settings → API** and copy two values:

--- a/adventure.html
+++ b/adventure.html
@@ -13,6 +13,7 @@
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
             <a href="play.html" class="nav__link">Game Session</a>
+            <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>
             <a href="adventure.html" class="nav__link nav__link--active">Adventure</a>

--- a/adventure.html
+++ b/adventure.html
@@ -12,7 +12,8 @@
         <nav class="nav">
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
-            <a href="play.html" class="nav__link">Game Session</a>
+            <a href="play-ai.html" class="nav__link">Play vs AI</a>
+            <a href="dm.html" class="nav__link">DM</a>
             <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>

--- a/battlemap.js
+++ b/battlemap.js
@@ -47,7 +47,8 @@
   var KIND_COLOR = { monster: '#c0392b', npc: '#9b59b6', player: '#4aa3df' };
 
   function defaultMap() {
-    return { v: 1, grid: 'square', cols: 16, rows: 12, terrain: {}, areas: [], starts: null, bg: null };
+    return { v: 1, grid: 'square', cols: 16, rows: 12, terrain: {}, areas: [], starts: null, bg: null,
+      fog: false, revealed: {} };
   }
 
   // Copy a { players:[], monsters:[], npcs:[] } start-zone spec (cells only).
@@ -459,8 +460,30 @@
     }
     drawTerrain(m);
     drawGrid(m);
-    drawAreas(m);
+    drawFog(m);        // fog over unrevealed cells (opaque for players, tint for DM)
+    drawAreas(m);      // revealed areas + tokens ride above the fog
     drawTokens(m);
+  }
+
+  // Fog of war: paint every cell the players have not yet discovered.
+  // In 'view' mode (the player client) fog is opaque — the terrain and
+  // background under it were never sent anyway (see visibility.js). In
+  // 'design'/'play' (the DM at the table) it's a light tint so the DM
+  // sees the whole map but knows what remains hidden.
+  function drawFog(m) {
+    if (!map.fog) return;
+    var occlude = (mode === 'view');
+    var revealed = map.revealed || {};
+    CTX.save();
+    CTX.fillStyle = occlude ? 'rgba(8,9,12,0.98)' : 'rgba(8,9,12,0.42)';
+    for (var row = 0; row < map.rows; row++) {
+      for (var col = 0; col < map.cols; col++) {
+        if (revealed[col + ',' + row]) continue;
+        if (m.grid === 'hex') fillCellShape(col, row, m);
+        else CTX.fillRect(col * m.cell, row * m.cell, m.cell, m.cell);
+      }
+    }
+    CTX.restore();
   }
 
   /* ---- Placement ---- */
@@ -951,10 +974,14 @@
     getMap: function () {
       var terrain = {};
       for (var k in map.terrain) if (map.terrain.hasOwnProperty(k)) terrain[k] = map.terrain[k];
+      var revealed = {};
+      for (var rk in (map.revealed || {})) if (map.revealed.hasOwnProperty(rk)) revealed[rk] = 1;
       var areas = (map.areas || []).map(function (a) {
-        return { n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '', dm: a.dm || '' };
+        return { n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '', dm: a.dm || '',
+          hidden: !!a.hidden, revealed: !!a.revealed };
       });
-      return { v: 1, grid: map.grid, cols: map.cols, rows: map.rows, terrain: terrain, areas: areas, starts: copyStarts(map.starts), bg: map.bg || null };
+      return { v: 1, grid: map.grid, cols: map.cols, rows: map.rows, terrain: terrain, areas: areas,
+        starts: copyStarts(map.starts), bg: map.bg || null, fog: !!map.fog, revealed: revealed };
     },
     setMap: function (data) {
       map = data ? {
@@ -964,10 +991,13 @@
         rows: Math.max(4, Math.min(60, (data.rows | 0) || 12)),
         terrain: data.terrain || {},
         areas: (data.areas || []).map(function (a) {
-          return { n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '', dm: a.dm || '' };
+          return { n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '', dm: a.dm || '',
+            hidden: !!a.hidden, revealed: !!a.revealed };
         }),
         starts: copyStarts(data.starts),
-        bg: data.bg || null
+        bg: data.bg || null,
+        fog: !!data.fog,
+        revealed: data.revealed || {}
       } : defaultMap();
       selectedArea = null;
       loadBg();
@@ -980,6 +1010,44 @@
     // Areas for the AI DM context (read-aloud + secret DM notes per number).
     getAreas: function () { return (map.areas || []).slice(); },
     selectedArea: function () { return selectedArea; },
+
+    /* ---- Fog of war / progressive reveal (DM controls) ----
+       The DM reveals parts of the map; visibility.js strips everything
+       still hidden before the player projection is synced. */
+    setFog: function (on) { map.fog = !!on; render(); if (cb.onChange) cb.onChange(); },
+    isFog: function () { return !!map.fog; },
+    isRevealed: function (col, row) { return !!(map.revealed && map.revealed[col + ',' + row]); },
+    revealCell: function (col, row) {
+      if (!inBounds(col, row)) return;
+      if (!map.revealed) map.revealed = {};
+      map.revealed[col + ',' + row] = 1;
+      render(); if (cb.onChange) cb.onChange();
+    },
+    // Reveal a cell and its neighbourhood (radius in cells; default 1).
+    revealAround: function (col, row, radius) {
+      radius = (radius == null ? 1 : radius | 0);
+      if (!map.revealed) map.revealed = {};
+      for (var dr = -radius; dr <= radius; dr++) {
+        for (var dc = -radius; dc <= radius; dc++) {
+          var cc = col + dc, rr = row + dr;
+          if (inBounds(cc, rr)) map.revealed[cc + ',' + rr] = 1;
+        }
+      }
+      render(); if (cb.onChange) cb.onChange();
+    },
+    revealAll: function () {
+      if (!map.revealed) map.revealed = {};
+      for (var row = 0; row < map.rows; row++) {
+        for (var col = 0; col < map.cols; col++) map.revealed[col + ',' + row] = 1;
+      }
+      render(); if (cb.onChange) cb.onChange();
+    },
+    clearRevealed: function () { map.revealed = {}; render(); if (cb.onChange) cb.onChange(); },
+    // Mark a numbered area revealed (shown to players) — or hide it again.
+    revealArea: function (n, on) {
+      (map.areas || []).forEach(function (a) { if (a.n === n) a.revealed = (on !== false); });
+      render(); if (cb.onChange) cb.onChange();
+    },
 
     grid: function () { return map.grid; },
     size: function () { return { cols: map.cols, rows: map.rows }; },

--- a/battlemap.js
+++ b/battlemap.js
@@ -48,8 +48,18 @@
 
   function defaultMap() {
     return { v: 1, grid: 'square', cols: 16, rows: 12, terrain: {}, areas: [], starts: null, bg: null,
-      fog: false, revealed: {} };
+      fog: false, revealed: {}, markers: [] };
   }
+
+  // Point markers (traps / secret doors / hidden treasure). DM-only until
+  // `revealed`; visibility.js drops unrevealed ones from the player view.
+  var MARKER_TYPES = {
+    trap:     { glyph: '⚠', color: '#c0392b', label: 'Trap' },
+    secret:   { glyph: '⚿', color: '#9b59b6', label: 'Secret' },
+    treasure: { glyph: '✦', color: '#e1b12c', label: 'Treasure' }
+  };
+  var markerSeq = 0;
+  function newMarkerId() { return 'mk' + (++markerSeq) + '_' + Date.now().toString(36); }
 
   // Copy a { players:[], monsters:[], npcs:[] } start-zone spec (cells only).
   function copyStarts(s) {
@@ -66,9 +76,13 @@
   var combatants = [];         // live array from play.js (read x/y off each)
   var map = defaultMap();
   var bgImage = null;          // Image built from map.bg
-  var tool = 'select';         // 'select' | 'paint' | 'erase' | 'area'
+  var tool = 'select';         // 'select' | 'paint' | 'erase' | 'area' | 'reveal' | 'hide' | 'marker'
   var paintTerrain = 'wall';
+  var markerType = 'trap';     // type dropped by the 'marker' tool
+  var autoReveal = false;      // fog: auto-clear cells around player tokens
+  var autoRevealRadius = 2;
   var selectedArea = null;     // area object currently being edited (design)
+  var selectedMarker = null;   // trap/secret/treasure marker selected (DM)
   var areaEditorEl = null;     // inline area editor built by buildToolbar
   var legendEl = null;         // HTML legend element (created lazily)
   // Interaction mode:
@@ -461,8 +475,40 @@
     drawTerrain(m);
     drawGrid(m);
     drawFog(m);        // fog over unrevealed cells (opaque for players, tint for DM)
+    drawMarkers(m);    // traps/secrets (DM sees unrevealed faded; players get only revealed)
     drawAreas(m);      // revealed areas + tokens ride above the fog
     drawTokens(m);
+  }
+
+  function drawMarkers(m) {
+    var list = map.markers || [];
+    for (var i = 0; i < list.length; i++) {
+      var mk = list[i];
+      if (mk.x == null || mk.y == null || !inBounds(mk.x, mk.y)) continue;
+      var t = MARKER_TYPES[mk.type] || MARKER_TYPES.trap;
+      var c = cellCenter(mk.x, mk.y, m);
+      var r = Math.max(9, (m.grid === 'hex' ? m.size : m.cell) * 0.3);
+      var dim = (mode !== 'view' && !mk.revealed);   // DM: unrevealed = faded + dashed
+      CTX.save();
+      CTX.globalAlpha = dim ? 0.6 : 1;
+      CTX.beginPath();
+      CTX.moveTo(c.x, c.y - r); CTX.lineTo(c.x + r, c.y);
+      CTX.lineTo(c.x, c.y + r); CTX.lineTo(c.x - r, c.y); CTX.closePath();
+      CTX.fillStyle = 'rgba(18,20,26,.92)'; CTX.fill();
+      CTX.lineWidth = 2;
+      if (dim) CTX.setLineDash([4, 3]);
+      CTX.strokeStyle = t.color; CTX.stroke();
+      CTX.setLineDash([]);
+      CTX.fillStyle = t.color;
+      CTX.font = 'bold ' + Math.round(r * 1.05) + 'px "Open Sans", sans-serif';
+      CTX.textAlign = 'center'; CTX.textBaseline = 'middle';
+      CTX.fillText(t.glyph, c.x, c.y + 0.5);
+      if (selectedMarker === mk) {
+        CTX.globalAlpha = 1; CTX.lineWidth = 2; CTX.strokeStyle = '#e1b12c';
+        CTX.beginPath(); CTX.arc(c.x, c.y, r + 3, 0, Math.PI * 2); CTX.stroke();
+      }
+      CTX.restore();
+    }
   }
 
   // Fog of war: paint every cell the players have not yet discovered.
@@ -616,6 +662,58 @@
     if (cb.onAreaSelect) cb.onAreaSelect(a || null);
   }
 
+  /* ---- Markers (traps / secret doors / treasure) ---- */
+  function markerAt(col, row) {
+    var list = map.markers || [];
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].x === col && list[i].y === row) return list[i];
+    }
+    return null;
+  }
+  function addMarker(col, row, type) {
+    if (!map.markers) map.markers = [];
+    var t = MARKER_TYPES[type] ? type : 'trap';
+    var mk = { id: newMarkerId(), x: col, y: row, type: t, label: '', note: '', revealed: false };
+    map.markers.push(mk);
+    selectMarker(mk);
+    render();
+    if (cb.onChange) cb.onChange();
+    return mk;
+  }
+  function removeMarker(mk) {
+    map.markers = (map.markers || []).filter(function (x) { return x !== mk; });
+    if (selectedMarker === mk) selectMarker(null);
+    render();
+    if (cb.onChange) cb.onChange();
+  }
+  function selectMarker(mk) {
+    selectedMarker = mk || null;
+    if (cb.onMarkerSelect) cb.onMarkerSelect(mk || null);
+  }
+  function revealMarker(mk, on) {
+    if (!mk) return;
+    mk.revealed = (on !== false);
+    render();
+    if (cb.onChange) cb.onChange();
+  }
+
+  // Fog: reveal a radius of cells around every placed player token.
+  function autoRevealPlayers() {
+    if (!map.fog || !autoReveal) return;
+    if (!map.revealed) map.revealed = {};
+    var changed = false;
+    combatants.forEach(function (c) {
+      if (c.kind !== 'player' || c.x == null || c.y == null) return;
+      for (var dr = -autoRevealRadius; dr <= autoRevealRadius; dr++) {
+        for (var dc = -autoRevealRadius; dc <= autoRevealRadius; dc++) {
+          var cc = c.x + dc, rr = c.y + dr, key = cc + ',' + rr;
+          if (inBounds(cc, rr) && !map.revealed[key]) { map.revealed[key] = 1; changed = true; }
+        }
+      }
+    });
+    return changed;
+  }
+
   /* ---- Pointer interaction ---- */
   function evPos(ev) {
     var rect = CV.getBoundingClientRect();
@@ -628,6 +726,8 @@
     var key = cell.col + ',' + cell.row;
     if (key === lastPaintKey) return;
     lastPaintKey = key;
+    if (tool === 'reveal') { if (!map.revealed) map.revealed = {}; map.revealed[key] = 1; render(); return; }
+    if (tool === 'hide') { if (map.revealed) delete map.revealed[key]; render(); return; }
     if (tool === 'erase') delete map.terrain[key];
     else map.terrain[key] = paintTerrain;
     render();
@@ -649,6 +749,22 @@
       return;
     }
 
+    // Fog brush: the DM paints revealed/hidden cells (also works in play mode).
+    if ((tool === 'reveal' || tool === 'hide') && mode !== 'view') {
+      lastPaintKey = null;
+      painting = true;
+      paintAt(cell);
+      try { CV.setPointerCapture(ev.pointerId); } catch (e) { /* ignore */ }
+      return;
+    }
+
+    // Marker tool: drop a trap/secret/treasure, or select an existing one.
+    if (tool === 'marker' && mode !== 'view') {
+      var mk = markerAt(cell.col, cell.row);
+      if (mk) selectMarker(mk); else addMarker(cell.col, cell.row, markerType);
+      return;
+    }
+
     if (tool === 'area' && mode === 'design') {
       var existing = areaAt(cell.col, cell.row);
       if (existing) selectArea(existing); else addArea(cell.col, cell.row);
@@ -667,7 +783,10 @@
       render();
       return;
     }
-    // no token — maybe an area pin (tap to read it, in any mode)
+    // no token — maybe a marker (traps/secrets), tap to select
+    var mk2 = markerAt(cell.col, cell.row);
+    if (mk2) { selectMarker(mk2); render(); return; }
+    // …or an area pin (tap to read it, in any mode)
     var area = areaAt(cell.col, cell.row);
     if (area) { selectArea(area); render(); return; }
     selectedId = null;
@@ -705,6 +824,7 @@
     }
     drag = null;
     showDistance(null);
+    if (moved) autoRevealPlayers();   // fog clears around a player as they move
     render();
     if (moved && cb.onMove) cb.onMove(d.id, d.x, d.y);
   }
@@ -749,7 +869,8 @@
 
   /* ---- Editing toolbar (design mode) ---- */
   function setTool(name) {
-    tool = (name === 'paint' || name === 'erase' || name === 'area') ? name : 'select';
+    var ok = { paint: 1, erase: 1, area: 1, reveal: 1, hide: 1, marker: 1 };
+    tool = ok[name] ? name : 'select';
     if (!toolbarEl) return;
     var btns = toolbarEl.querySelectorAll('.bm-tool');
     for (var i = 0; i < btns.length; i++) {
@@ -928,7 +1049,7 @@
     // Point the map at the live combatant array; places any newcomers.
     setCombatants: function (list) {
       combatants = list || [];
-      if (CTX) { ensurePlacement(); render(); }
+      if (CTX) { ensurePlacement(); autoRevealPlayers(); render(); }
     },
 
     setSelected: function (id) { selectedId = (id == null ? null : id); render(); },
@@ -980,8 +1101,13 @@
         return { n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '', dm: a.dm || '',
           hidden: !!a.hidden, revealed: !!a.revealed };
       });
+      var markers = (map.markers || []).map(function (mk) {
+        return { id: mk.id, x: mk.x, y: mk.y, type: mk.type, label: mk.label || '',
+          note: mk.note || '', revealed: !!mk.revealed };
+      });
       return { v: 1, grid: map.grid, cols: map.cols, rows: map.rows, terrain: terrain, areas: areas,
-        starts: copyStarts(map.starts), bg: map.bg || null, fog: !!map.fog, revealed: revealed };
+        markers: markers, starts: copyStarts(map.starts), bg: map.bg || null,
+        fog: !!map.fog, revealed: revealed };
     },
     setMap: function (data) {
       map = data ? {
@@ -994,17 +1120,23 @@
           return { n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '', dm: a.dm || '',
             hidden: !!a.hidden, revealed: !!a.revealed };
         }),
+        markers: (data.markers || []).map(function (mk) {
+          return { id: mk.id || newMarkerId(), x: mk.x, y: mk.y,
+            type: MARKER_TYPES[mk.type] ? mk.type : 'trap',
+            label: mk.label || '', note: mk.note || '', revealed: !!mk.revealed };
+        }),
         starts: copyStarts(data.starts),
         bg: data.bg || null,
         fog: !!data.fog,
         revealed: data.revealed || {}
       } : defaultMap();
       selectedArea = null;
+      selectedMarker = null;
       loadBg();
       syncToolbar();
       updateAreaEditor();
       renderLegend();
-      if (CTX) { ensurePlacement(); render(); }
+      if (CTX) { ensurePlacement(); autoRevealPlayers(); render(); }
     },
 
     // Areas for the AI DM context (read-aloud + secret DM notes per number).
@@ -1043,6 +1175,21 @@
       render(); if (cb.onChange) cb.onChange();
     },
     clearRevealed: function () { map.revealed = {}; render(); if (cb.onChange) cb.onChange(); },
+    // Auto-clear fog around player tokens as they move (DM preference).
+    setAutoReveal: function (on, radius) {
+      autoReveal = !!on;
+      if (radius != null) autoRevealRadius = Math.max(0, radius | 0);
+      if (autoRevealPlayers()) { render(); if (cb.onChange) cb.onChange(); }
+    },
+    isAutoReveal: function () { return autoReveal; },
+    // Markers (traps / secret doors / treasure).
+    setMarkerType: function (t) { if (MARKER_TYPES[t]) markerType = t; },
+    getMarkers: function () { return (map.markers || []).slice(); },
+    selectedMarker: function () { return selectedMarker; },
+    selectMarker: function (mk) { selectMarker(mk || null); render(); },
+    revealMarker: revealMarker,
+    removeMarker: removeMarker,
+    markerTypes: function () { return MARKER_TYPES; },
     // Mark a numbered area revealed (shown to players) — or hide it again.
     revealArea: function (n, on) {
       (map.areas || []).forEach(function (a) { if (a.n === n) a.revealed = (on !== false); });

--- a/character.html
+++ b/character.html
@@ -12,7 +12,8 @@
         <nav class="nav">
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
-            <a href="play.html" class="nav__link">Game Session</a>
+            <a href="play-ai.html" class="nav__link">Play vs AI</a>
+            <a href="dm.html" class="nav__link">DM</a>
             <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link nav__link--active">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>

--- a/character.html
+++ b/character.html
@@ -13,6 +13,7 @@
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
             <a href="play.html" class="nav__link">Game Session</a>
+            <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link nav__link--active">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>
             <a href="adventure.html" class="nav__link">Adventure</a>

--- a/cloud.js
+++ b/cloud.js
@@ -83,6 +83,42 @@
     return client.from('play_sessions').delete().eq('id', id);
   }
 
+  /* ---- Player projections (the sanitized view players receive) ----
+     The DM upserts a role-scoped view (from Visibility.playerView) here;
+     group members read/subscribe to it. The full state in play_sessions
+     stays owner-only, so hidden info never reaches a player client. */
+  // rec: { session_id, group_id, title, view }
+  function savePlayerView(rec) {
+    return client.from('play_player_views').upsert({
+      session_id: rec.session_id,
+      owner: currentUser && currentUser.id,
+      group_id: (rec.group_id == null ? null : rec.group_id),
+      title: rec.title || null,
+      view: rec.view,
+      updated_at: new Date().toISOString()
+    }, { onConflict: 'session_id' }).select().single();
+  }
+  function deletePlayerView(sessionId) {
+    return client.from('play_player_views').delete().eq('session_id', sessionId);
+  }
+  function loadPlayerView(sessionId) {
+    return client.from('play_player_views').select('*').eq('session_id', sessionId).maybeSingle();
+  }
+  // Shared views the current user may open (their own + their groups').
+  function listPlayerViews() {
+    return client.from('play_player_views')
+      .select('session_id,title,updated_at,group_id,owner')
+      .order('updated_at', { ascending: false });
+  }
+  function subscribePlayerView(sessionId, cb) {
+    var ch = client.channel('ppv_' + sessionId)
+      .on('postgres_changes',
+        { event: '*', schema: 'public', table: 'play_player_views', filter: 'session_id=eq.' + sessionId },
+        function (payload) { cb(payload.new || null); })
+      .subscribe();
+    return ch;
+  }
+
   /* ---- User collections (characters / adventures / encounters) ---- */
   function getCollection(kind) {
     return client.from('user_collections').select('data')
@@ -130,6 +166,9 @@
     signIn: signIn, signUp: signUp, signOut: signOut,
     listSessions: listSessions, saveSession: saveSession,
     loadSession: loadSession, deleteSession: deleteSession,
+    savePlayerView: savePlayerView, deletePlayerView: deletePlayerView,
+    loadPlayerView: loadPlayerView, listPlayerViews: listPlayerViews,
+    subscribePlayerView: subscribePlayerView,
     getCollection: getCollection, saveCollection: saveCollection,
     listGroups: listGroups, createGroup: createGroup,
     joinGroup: joinGroup, setSessionShare: setSessionShare,

--- a/combat-engine.js
+++ b/combat-engine.js
@@ -76,7 +76,8 @@
       conditions: [],
       attacks: [],
       x: null,             // battlemap column (null = not placed yet)
-      y: null              // battlemap row
+      y: null,             // battlemap row
+      hidden: false        // DM-only: not yet revealed to players (role-based visibility)
     };
   }
 
@@ -184,6 +185,9 @@
   function combatantLabel(c) { return '#' + c.id + ' ' + c.name; }
   function hasHp(c) { return c.maxHp != null; }
   function canBeTargeted(c) { return c.ac != null; }
+  // Role-based visibility: is this combatant currently visible to players?
+  function isHidden(c) { return !!c.hidden; }
+  function setHidden(c, hidden) { c.hidden = !!hidden; return c; }
 
   /* ---- Conditions ---- */
   var CONDITION_INFO = {
@@ -318,11 +322,12 @@
   /* ---- 5. (De)serialization ---- */
   function serializeCombatant(c) {
     var o = {
-      kind: c.kind, name: c.name, hp: c.hp, maxHp: c.maxHp, ac: c.ac,
+      id: c.id, kind: c.kind, name: c.name, hp: c.hp, maxHp: c.maxHp, ac: c.ac,
       dead: c.dead, initiative: c.initiative, initRoll: c.initRoll,
       initMod: c.initMod, conditions: c.conditions.slice(),
       x: (c.x == null ? null : c.x), y: (c.y == null ? null : c.y)
     };
+    if (c.hidden) o.hidden = true;   // only carried when set (keeps old saves compatible)
     if (c.kind === 'monster' && c.template) o.templateSlug = c.template.slug;
     else if (c.kind === 'monster') o.attacks = c.attacks;   // custom monster (no library template)
     if (c.kind === 'npc') o.attacks = c.attacks;
@@ -330,6 +335,8 @@
   }
   function deserializeCombatant(o) {
     var c = baseCombatant(o.kind, o.name);
+    if (o.id != null) { c.id = o.id; bumpIdPast(o.id); }  // stable ids across a synced snapshot
+    c.hidden = !!o.hidden;
     c.hp = (o.hp == null ? null : o.hp);
     c.maxHp = (o.maxHp == null ? null : o.maxHp);
     c.ac = (o.ac == null ? null : o.ac);
@@ -367,6 +374,7 @@
     parseSheetAttack: parseSheetAttack, sheetInitMod: sheetInitMod,
     findCombatant: findCombatant, combatantLabel: combatantLabel,
     hasHp: hasHp, canBeTargeted: canBeTargeted,
+    isHidden: isHidden, setHidden: setHidden,
     // conditions
     CONDITION_INFO: CONDITION_INFO, conditionInfo: conditionInfo,
     addCondition: addCondition, removeCondition: removeCondition,

--- a/dm.html
+++ b/dm.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=play.html?role=dm">
+        <title>DM Console — Dice &amp; Monsters</title>
+    </head>
+    <body>
+        <p>Opening the DM console… <a href="play.html?role=dm">Continue</a></p>
+        <script>location.replace('play.html?role=dm');</script>
+    </body>
+</html>

--- a/encounter.html
+++ b/encounter.html
@@ -12,7 +12,8 @@
         <nav class="nav">
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link nav__link--active">Encounter</a>
-            <a href="play.html" class="nav__link">Game Session</a>
+            <a href="play-ai.html" class="nav__link">Play vs AI</a>
+            <a href="dm.html" class="nav__link">DM</a>
             <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>

--- a/encounter.html
+++ b/encounter.html
@@ -13,6 +13,7 @@
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link nav__link--active">Encounter</a>
             <a href="play.html" class="nav__link">Game Session</a>
+            <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>
             <a href="adventure.html" class="nav__link">Adventure</a>

--- a/groups.html
+++ b/groups.html
@@ -13,6 +13,7 @@
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
             <a href="play.html" class="nav__link">Game Session</a>
+            <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link nav__link--active">Groups</a>
             <a href="adventure.html" class="nav__link">Adventure</a>

--- a/groups.html
+++ b/groups.html
@@ -12,7 +12,8 @@
         <nav class="nav">
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
-            <a href="play.html" class="nav__link">Game Session</a>
+            <a href="play-ai.html" class="nav__link">Play vs AI</a>
+            <a href="dm.html" class="nav__link">DM</a>
             <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link nav__link--active">Groups</a>

--- a/index.html
+++ b/index.html
@@ -24,12 +24,28 @@
                         and save them ready to play. For the DM.
                     </span>
                 </a>
-                <a class="home-card" href="play.html">
-                    <span class="home-card__icon">🎲</span>
-                    <span class="home-card__title">Game Session</span>
+                <a class="home-card" href="play-ai.html">
+                    <span class="home-card__icon">🤖</span>
+                    <span class="home-card__title">Play vs AI DM</span>
                     <span class="home-card__desc">
-                        Run the fight live — initiative, turns, attacks and the
-                        combat log. Send an encounter here from the planner.
+                        Single-player: the AI runs the dungeon. It sees the whole
+                        map and every secret; you see only what your party finds.
+                    </span>
+                </a>
+                <a class="home-card" href="dm.html">
+                    <span class="home-card__icon">🎲</span>
+                    <span class="home-card__title">DM Console</span>
+                    <span class="home-card__desc">
+                        Run the table yourself — initiative, HP, the whole map and
+                        every secret. Reveal creatures and rooms as players explore.
+                    </span>
+                </a>
+                <a class="home-card" href="player.html">
+                    <span class="home-card__icon">🛡️</span>
+                    <span class="home-card__title">Player</span>
+                    <span class="home-card__desc">
+                        Your seat when a DM leads. You see only your character and
+                        what's been revealed — no secrets, no monster stats.
                     </span>
                 </a>
                 <a class="home-card" href="character.html">

--- a/play-ai.html
+++ b/play-ai.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=play.html?role=ai">
+        <title>Play vs AI DM — Dice &amp; Monsters</title>
+    </head>
+    <body>
+        <p>Opening the AI Dungeon Master… <a href="play.html?role=ai">Continue</a></p>
+        <script>location.replace('play.html?role=ai');</script>
+    </body>
+</html>

--- a/play.html
+++ b/play.html
@@ -13,6 +13,7 @@
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
             <a href="play.html" class="nav__link nav__link--active">Game Session</a>
+            <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>
             <a href="adventure.html" class="nav__link">Adventure</a>
@@ -145,6 +146,29 @@
             <div class="monster__list"></div>
         </section>
 
+        <!-- DM visibility controls: what the players' screens receive.
+             Hidden creatures / unrevealed map cells are stripped before
+             the player projection is published (see visibility.js). -->
+        <section class="reveal" id="reveal-panel">
+            <div class="reveal__head">
+                <h2 class="reveal__title">👁 Players see</h2>
+                <a class="reveal__open" href="player.html" target="_blank" rel="noopener">Open the Player view ↗</a>
+            </div>
+            <div class="reveal__row">
+                <label class="reveal__toggle">
+                    <input type="checkbox" id="reveal-fog"> Fog of war (players see only what they've explored)
+                </label>
+                <button class="btn-reveal-map" type="button">Reveal whole map</button>
+                <button class="btn-reset-fog" type="button">Reset fog</button>
+            </div>
+            <div class="reveal__row">
+                <span class="reveal__label">Creatures:</span>
+                <button class="btn-hide-all" type="button">Hide all from players</button>
+                <button class="btn-reveal-all" type="button">Reveal all to players</button>
+                <span class="reveal__hint">Use 👁/🙈 on each creature below to reveal it one at a time.</span>
+            </div>
+        </section>
+
         <!-- AI Dungeon Master -->
         <section class="ai" id="ai-dm">
             <div class="ai__head">
@@ -227,6 +251,7 @@
         <script src="monsters-data.js"></script>
         <script src="combat-engine.js"></script>
         <script src="battlemap.js"></script>
+        <script src="visibility.js"></script>
         <script src="ai-context.js"></script>
         <script src="ai-client.js"></script>
         <script src="ai-dm.js"></script>

--- a/play.html
+++ b/play.html
@@ -12,7 +12,8 @@
         <nav class="nav">
             <a href="index.html" class="nav__link">Home</a>
             <a href="encounter.html" class="nav__link">Encounter</a>
-            <a href="play.html" class="nav__link nav__link--active">Game Session</a>
+            <a href="play-ai.html" class="nav__link" data-role-link="ai">Play vs AI</a>
+            <a href="dm.html" class="nav__link" data-role-link="dm">DM</a>
             <a href="player.html" class="nav__link">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
             <a href="groups.html" class="nav__link">Groups</a>

--- a/play.html
+++ b/play.html
@@ -134,6 +134,20 @@
                 <p class="bm-areacard__read"></p>
                 <p class="bm-areacard__dm"></p>
             </div>
+            <div id="battlemap-marker" class="bm-markercard" hidden>
+                <button class="bm-markercard__close" type="button" aria-label="Close">✕</button>
+                <h3 class="bm-markercard__title"></h3>
+                <label class="bm-markercard__field">Label (players see this when revealed)
+                    <input type="text" id="marker-label" class="bm-markercard__input" placeholder="e.g. Pressure plate">
+                </label>
+                <label class="bm-markercard__field">Secret DM note (never sent to players)
+                    <input type="text" id="marker-note" class="bm-markercard__input" placeholder="e.g. DC 15 Dex, 2d10 darts">
+                </label>
+                <div class="bm-markercard__actions">
+                    <button class="btn-marker-reveal" type="button">Reveal to players</button>
+                    <button class="btn-marker-remove" type="button">Remove</button>
+                </div>
+            </div>
             <p class="battlemap__hint">Drag tokens to move them (distance shows in feet). Tap a numbered area to read its notes. Add players and monsters above. The map is set up in the Encounter Planner or Adventure.</p>
         </section>
 
@@ -158,8 +172,27 @@
                 <label class="reveal__toggle">
                     <input type="checkbox" id="reveal-fog"> Fog of war (players see only what they've explored)
                 </label>
+                <label class="reveal__toggle">
+                    <input type="checkbox" id="reveal-auto"> Auto-reveal around players
+                </label>
                 <button class="btn-reveal-map" type="button">Reveal whole map</button>
                 <button class="btn-reset-fog" type="button">Reset fog</button>
+            </div>
+            <div class="reveal__row" id="reveal-brush-row">
+                <span class="reveal__label">Fog brush:</span>
+                <span class="reveal__seg" id="reveal-brush">
+                    <button type="button" class="is-active" data-brush="select">Move tokens</button>
+                    <button type="button" data-brush="reveal">Reveal ▢</button>
+                    <button type="button" data-brush="hide">Hide ▢</button>
+                </span>
+                <span class="reveal__hint">Draw on the map to reveal or re-hide cells.</span>
+            </div>
+            <div class="reveal__row">
+                <span class="reveal__label">Drop marker:</span>
+                <button class="btn-marker" type="button" data-marker="trap">⚠ Trap</button>
+                <button class="btn-marker" type="button" data-marker="secret">⚿ Secret</button>
+                <button class="btn-marker" type="button" data-marker="treasure">✦ Treasure</button>
+                <span class="reveal__hint">Then click a cell. Tap a marker to reveal / edit it.</span>
             </div>
             <div class="reveal__row">
                 <span class="reveal__label">Creatures:</span>

--- a/play.js
+++ b/play.js
@@ -1607,13 +1607,20 @@
     var role = currentRole();
     var h1 = document.querySelector('.topbar h1');
     var tag = document.querySelector('.topbar .tagline');
+    // A body class drives the per-role layout in CSS, so each seat shows
+    // only its own components (no shared DOM peeking through).
+    document.body.classList.add('role-' + role);
+    // Highlight the matching gameplay nav entry.
+    var navLink = document.querySelector('.nav__link[data-role-link="' + role + '"]');
+    if (navLink) navLink.classList.add('nav__link--active');
+
     if (role === 'dm') {
-      var aiPanel = document.querySelector('#ai-dm');
-      if (aiPanel) aiPanel.hidden = true;           // human DM: no AI DM panel
       if (h1) h1.textContent = 'DM Console';
       if (tag) tag.textContent = 'You run the world. Reveal the map and creatures as the players discover them.';
       document.title = 'DM Console — Dice & Monsters';
     } else {
+      // AI is the DM: the human is a player, so the DM reveal controls
+      // (hidden via CSS) don't apply here; the AI DM panel does.
       if (h1) h1.textContent = 'Play vs AI DM';
       if (tag) tag.textContent = 'The AI is your Dungeon Master — it sees the whole map; you see only what your party has found.';
       document.title = 'Play vs AI DM — Dice & Monsters';

--- a/play.js
+++ b/play.js
@@ -34,6 +34,8 @@
   var cloudSessionTitle = '';
   var cloudTimer = null;
   var cloudGroups = [];          // groups I belong to
+  var cloudShareOn = false;      // is the active session shared with players?
+  var cloudShareGroupId = null;  // which group it's shared with
   var viewerMode = false;        // watching someone else's shared session (read-only)
   var liveChannel = null;        // active realtime subscription
 
@@ -1221,10 +1223,25 @@
     if (!window.Cloud || !Cloud.available() || !Cloud.user() || !cloudSessionId) return;
     clearTimeout(cloudTimer);
     cloudTimer = setTimeout(function () {
-      Cloud.saveSession({ id: cloudSessionId, title: cloudSessionTitle, state: snapshot() })
+      var snap = snapshot();
+      Cloud.saveSession({ id: cloudSessionId, title: cloudSessionTitle, state: snap })
         .then(function (res) { if (res && res.error) cloudStatus('Cloud save failed: ' + res.error.message); })
         .catch(function (e) { cloudStatus('Cloud save failed.'); });
+      pushPlayerView(snap);   // the sanitized projection players actually receive
     }, 2000);
+  }
+  // Publish the role-scoped player projection to the cloud (the ONLY thing
+  // players read). Full state goes to play_sessions (owner-only); this goes
+  // to play_player_views (group-readable). Enforces "hidden info never sent".
+  function pushPlayerView(snap) {
+    if (!cloudShareOn || !cloudShareGroupId || !cloudSessionId) return;
+    if (!Cloud.available() || !Cloud.user() || !window.Visibility) return;
+    Cloud.savePlayerView({
+      session_id: cloudSessionId,
+      group_id: cloudShareGroupId,
+      title: cloudSessionTitle,
+      view: window.Visibility.playerView(snap, {})
+    }).catch(function () { /* transient; next autosave retries */ });
   }
 
   function refreshCloudList() {
@@ -1248,7 +1265,7 @@
     el.cloudPanel.hidden = !signedIn;
     if (el.cloudSigninHint) el.cloudSigninHint.hidden = signedIn;
     if (signedIn) { refreshCloudList(); refreshGroups(); cloudActiveLabel(); }
-    else { cloudSessionId = null; cloudSessionTitle = ''; leaveViewerMode(); }
+    else { cloudSessionId = null; cloudSessionTitle = ''; cloudShareOn = false; cloudShareGroupId = null; leaveViewerMode(); }
   }
 
   function doSaveToCloud() {
@@ -1285,8 +1302,12 @@
         cloudSessionId = row.id;
         cloudSessionTitle = row.title;
         // reflect this session's share state in the controls
+        cloudShareOn = !!row.shared;
+        cloudShareGroupId = row.shared ? (row.group_id || null) : null;
         if (el.cloudShared) el.cloudShared.checked = !!row.shared;
-        if (row.group_id && el.cloudGroups) { el.cloudGroups.value = row.group_id; updateInviteDisplay(); }
+        if (row.group_id && el.cloudGroups) { el.cloudGroups.value = row.group_id; }
+        updateInviteDisplay();
+        if (cloudShareOn) pushPlayerView(row.state || {});
         persistState();
         cloudActiveLabel();
         logLine('Opened cloud session “' + row.title + '”.', 'spawn');
@@ -1307,7 +1328,7 @@
     if (!window.confirm('Delete this cloud session permanently?')) return;
     Cloud.deleteSession(id).then(function (res) {
       if (res.error) { cloudStatus('Delete failed: ' + res.error.message); return; }
-      if (id === cloudSessionId) { cloudSessionId = null; cloudSessionTitle = ''; cloudActiveLabel(); }
+      if (id === cloudSessionId) { cloudSessionId = null; cloudSessionTitle = ''; cloudShareOn = false; cloudShareGroupId = null; cloudActiveLabel(); }
       cloudStatus('Deleted.');
       refreshCloudList();
     });
@@ -1332,8 +1353,15 @@
     return null;
   }
   function updateInviteDisplay() {
+    if (!el.cloudInvite) return;
     var g = selectedGroup();
-    if (el.cloudInvite) el.cloudInvite.textContent = g ? ('Invite code: ' + g.invite_code) : '';
+    if (cloudShareOn && g && cloudSessionId) {
+      var link = playerJoinLink();
+      el.cloudInvite.innerHTML = 'Invite code <b>' + esc(g.invite_code) + '</b> · ' +
+        '<a href="' + esc(link) + '" target="_blank" rel="noopener">Player link ↗</a>';
+    } else {
+      el.cloudInvite.textContent = g ? ('Invite code: ' + g.invite_code) : '';
+    }
   }
   function doCreateGroup() {
     var name = window.prompt('Name this group / party:');
@@ -1362,10 +1390,22 @@
     if (shared && !g) { cloudStatus('Select or create a group to share with.'); el.cloudShared.checked = false; return; }
     Cloud.setSessionShare(cloudSessionId, g ? g.id : null, shared).then(function (res) {
       if (res.error) { cloudStatus('Share failed: ' + res.error.message); el.cloudShared.checked = !shared; return; }
-      cloudStatus(shared
-        ? ('Shared live with “' + g.name + '”. Players open it from their Cloud saves.')
-        : 'Sharing turned off.');
+      cloudShareOn = shared;
+      cloudShareGroupId = shared ? g.id : null;
+      if (shared) {
+        pushPlayerView(snapshot());   // publish the projection right away
+        cloudStatus('Shared live with “' + g.name + '”. Send players the invite link + code below.');
+      } else {
+        Cloud.deletePlayerView(cloudSessionId).catch(function () { /* ignore */ });
+        cloudStatus('Sharing turned off.');
+      }
+      updateInviteDisplay();
     });
+  }
+  function playerJoinLink() {
+    if (!cloudSessionId) return '';
+    var base = window.location.href.replace(/[^\/]*(\?.*)?$/, '');
+    return base + 'player.html?s=' + cloudSessionId;
   }
 
   function subscribeLive(id) {

--- a/play.js
+++ b/play.js
@@ -1455,8 +1455,10 @@
       wrap: document.querySelector('#battlemap-wrap'),
       distanceEl: document.querySelector('#battlemap-dist'),
       onMove: function () { scheduleSave(); },
+      onChange: function () { scheduleSave(); },   // fog paint / marker drops → save + republish
       onSelect: function (id) { selectMapToken(id); },
-      onAreaSelect: showAreaCard
+      onAreaSelect: showAreaCard,
+      onMarkerSelect: showMarkerCard
     });
     BM.setMode(viewerMode ? 'view' : 'play');
 
@@ -1478,10 +1480,89 @@
       fog.checked = BM.isFog();
       fog.addEventListener('change', function () { BM.setFog(fog.checked); persistState(); });
     }
+    var auto = document.querySelector('#reveal-auto');
+    if (auto && BM) {
+      auto.checked = BM.isAutoReveal();
+      auto.addEventListener('change', function () { BM.setAutoReveal(auto.checked); persistState(); });
+    }
     bindClick('.btn-reveal-map', function () { if (BM) BM.revealAll(); persistState(); });
     bindClick('.btn-reset-fog', function () { if (BM) BM.clearRevealed(); persistState(); });
     bindClick('.btn-hide-all', function () { setAllHidden(true); });
     bindClick('.btn-reveal-all', function () { setAllHidden(false); });
+
+    // Fog brush: Move / Reveal / Hide (drives the battlemap tool in play mode).
+    var brush = document.querySelector('#reveal-brush');
+    if (brush && BM) {
+      brush.addEventListener('click', function (ev) {
+        var b = ev.target.closest('[data-brush]');
+        if (!b) return;
+        var which = b.getAttribute('data-brush');
+        BM.setTool(which === 'select' ? 'select' : which);
+        setActiveBrush(which);
+      });
+    }
+    // Marker drop buttons: arm the marker tool with a type.
+    var markerBtns = document.querySelectorAll('.btn-marker');
+    for (var i = 0; i < markerBtns.length; i++) {
+      markerBtns[i].addEventListener('click', function (ev) {
+        if (!BM) return;
+        BM.setMarkerType(ev.currentTarget.getAttribute('data-marker'));
+        BM.setTool('marker');
+        setActiveBrush(null);   // marker mode isn't one of the brush segments
+      });
+    }
+    initMarkerCard();
+  }
+  function setActiveBrush(which) {
+    var seg = document.querySelector('#reveal-brush');
+    if (!seg) return;
+    var btns = seg.querySelectorAll('[data-brush]');
+    for (var i = 0; i < btns.length; i++) {
+      btns[i].classList.toggle('is-active', which && btns[i].getAttribute('data-brush') === which);
+    }
+  }
+
+  var activeMarker = null;
+  function initMarkerCard() {
+    el.markerCard = document.querySelector('#battlemap-marker');
+    if (!el.markerCard) return;
+    el.markerCard.querySelector('.bm-markercard__close')
+      .addEventListener('click', function () { el.markerCard.hidden = true; window.Battlemap.selectMarker && window.Battlemap.selectMarker(null); });
+    var label = el.markerCard.querySelector('#marker-label');
+    var note = el.markerCard.querySelector('#marker-note');
+    label.addEventListener('input', function () { if (activeMarker) { activeMarker.label = label.value; scheduleSave(); } });
+    note.addEventListener('input', function () { if (activeMarker) { activeMarker.note = note.value; scheduleSave(); } });
+    el.markerCard.querySelector('.btn-marker-reveal').addEventListener('click', function () {
+      if (!activeMarker) return;
+      window.Battlemap.revealMarker(activeMarker, !activeMarker.revealed);
+      renderMarkerCard();
+      persistState();
+    });
+    el.markerCard.querySelector('.btn-marker-remove').addEventListener('click', function () {
+      if (!activeMarker) return;
+      window.Battlemap.removeMarker(activeMarker);
+      activeMarker = null;
+      el.markerCard.hidden = true;
+      persistState();
+    });
+  }
+  function showMarkerCard(mk) {
+    if (!el.markerCard) return;
+    activeMarker = mk || null;
+    if (!mk) { el.markerCard.hidden = true; return; }
+    renderMarkerCard();
+    el.markerCard.hidden = false;
+  }
+  function renderMarkerCard() {
+    if (!el.markerCard || !activeMarker) return;
+    var types = window.Battlemap.markerTypes();
+    var t = types[activeMarker.type] || {};
+    el.markerCard.querySelector('.bm-markercard__title').textContent =
+      (t.glyph || '') + ' ' + (t.label || 'Marker') + (activeMarker.revealed ? ' — shown to players' : ' — hidden');
+    el.markerCard.querySelector('#marker-label').value = activeMarker.label || '';
+    el.markerCard.querySelector('#marker-note').value = activeMarker.note || '';
+    el.markerCard.querySelector('.btn-marker-reveal').textContent =
+      activeMarker.revealed ? 'Hide from players' : 'Reveal to players';
   }
   function bindClick(sel, fn) {
     var b = document.querySelector(sel);

--- a/play.js
+++ b/play.js
@@ -83,9 +83,25 @@
   }
   function persistState() {
     if (viewerMode) return;   // viewers never write
-    try { window.localStorage.setItem(AUTOSAVE_KEY, JSON.stringify(snapshot())); }
+    var snap = snapshot();
+    try { window.localStorage.setItem(AUTOSAVE_KEY, JSON.stringify(snap)); }
     catch (e) { /* storage full / blocked — stays in memory */ }
+    publishPlayerView(snap);
     cloudAutosave();
+  }
+  // Publish the role-scoped PLAYER projection — the only combat state a
+  // player client is ever given. Hidden creatures, DM notes, monster
+  // stats, the raw log and AI transcript are stripped here, before this
+  // leaves the DM's seat (localStorage now; a player-readable Supabase
+  // column later). This is where the "hidden info is never sent" rule
+  // is enforced at the data layer, not in the player UI.
+  var PLAYER_VIEW_KEY = 'diceAndMonsters.playerProjection';
+  function publishPlayerView(snap) {
+    if (!window.Visibility) return;
+    try {
+      window.localStorage.setItem(PLAYER_VIEW_KEY,
+        JSON.stringify(window.Visibility.playerView(snap, {})));
+    } catch (e) { /* ignore */ }
   }
   function clearAutosave() {
     try { window.localStorage.removeItem(AUTOSAVE_KEY); } catch (e) { /* ignore */ }
@@ -239,6 +255,17 @@
       '<button class="btn-remove" data-action="remove">Remove</button>' +
     '</div>';
   }
+  // Per-creature visibility toggle. Players never receive a hidden
+  // creature (it's stripped in visibility.js before the projection is
+  // published) — this is not a UI hide, it controls what's sent.
+  function revealToggleHtml(c) {
+    if (c.kind === 'player') return '';
+    var shown = !c.hidden;
+    return '<button class="item__reveal ' + (shown ? 'is-shown' : 'is-hidden') +
+      '" data-action="toggle-hidden" title="' +
+      (shown ? 'Visible to players — click to hide' : 'Hidden from players — click to reveal') +
+      '">' + (shown ? '👁 shown' : '🙈 hidden') + '</button>';
+  }
   function cardHtml(c) {
     var active = c.id === state.activeId ? ' item--active' : '';
     var dead = c.dead ? ' item--dead' : '';
@@ -251,7 +278,7 @@
       '<div class="item' + kindCls + active + dead + '" data-id="' + c.id + '">' +
         '<div class="item__head">' +
           '<span class="item__name">#' + c.id + ' ' + esc(c.name) + '</span>' +
-          metaHtml(c) +
+          metaHtml(c) + revealToggleHtml(c) +
         '</div>' +
         hpBarHtml(c) + statsHtml(c) + controls +
       '</div>';
@@ -511,6 +538,11 @@
       DM.removeCondition(c, btn.getAttribute('data-cond'));
       rerenderCard(c);
       renderTurnOrder();
+    } else if (action === 'toggle-hidden') {
+      DM.setHidden(c, !c.hidden);
+      logLine(label(c) + (c.hidden ? ' is now hidden from players.' : ' is revealed to players.'), 'spawn');
+      rerenderCard(c);
+      persistState();   // republish the player projection immediately
     } else if (action === 'remove') {
       removeCombatant(id);
     }
@@ -1437,6 +1469,36 @@
     }
   }
 
+  // DM visibility controls (fog of war + reveal/hide creatures). Each
+  // action re-publishes the player projection so player screens update.
+  function initRevealPanel() {
+    var BM = window.Battlemap;
+    var fog = document.querySelector('#reveal-fog');
+    if (fog && BM) {
+      fog.checked = BM.isFog();
+      fog.addEventListener('change', function () { BM.setFog(fog.checked); persistState(); });
+    }
+    bindClick('.btn-reveal-map', function () { if (BM) BM.revealAll(); persistState(); });
+    bindClick('.btn-reset-fog', function () { if (BM) BM.clearRevealed(); persistState(); });
+    bindClick('.btn-hide-all', function () { setAllHidden(true); });
+    bindClick('.btn-reveal-all', function () { setAllHidden(false); });
+  }
+  function bindClick(sel, fn) {
+    var b = document.querySelector(sel);
+    if (b) b.addEventListener('click', fn);
+  }
+  function setAllHidden(hidden) {
+    if (viewerMode) return;
+    var n = 0;
+    state.combatants.forEach(function (c) {
+      if (c.kind !== 'player') { DM.setHidden(c, hidden); n++; }
+    });
+    if (!n) return;
+    logLine(hidden ? 'All creatures hidden from players.' : 'All creatures revealed to players.', 'spawn');
+    renderAll();
+    persistState();
+  }
+
   function showAreaCard(area) {
     if (!el.areaCard) return;
     if (!area) { el.areaCard.hidden = true; return; }
@@ -1452,7 +1514,33 @@
     el.areaCard.hidden = false;
   }
 
+  // Which seat is this: 'ai' (AI DM runs the game) or 'dm' (a human DM).
+  // The two share this game session; the role only toggles the AI panel
+  // and the page's framing. The player screen is the separate player.html.
+  function currentRole() {
+    try {
+      return (new URLSearchParams(window.location.search).get('role') === 'dm') ? 'dm' : 'ai';
+    } catch (e) { return 'ai'; }
+  }
+  function applyRole() {
+    var role = currentRole();
+    var h1 = document.querySelector('.topbar h1');
+    var tag = document.querySelector('.topbar .tagline');
+    if (role === 'dm') {
+      var aiPanel = document.querySelector('#ai-dm');
+      if (aiPanel) aiPanel.hidden = true;           // human DM: no AI DM panel
+      if (h1) h1.textContent = 'DM Console';
+      if (tag) tag.textContent = 'You run the world. Reveal the map and creatures as the players discover them.';
+      document.title = 'DM Console — Dice & Monsters';
+    } else {
+      if (h1) h1.textContent = 'Play vs AI DM';
+      if (tag) tag.textContent = 'The AI is your Dungeon Master — it sees the whole map; you see only what your party has found.';
+      document.title = 'Play vs AI DM — Dice & Monsters';
+    }
+  }
+
   function init() {
+    applyRole();
     el.loadSelect = document.querySelector('#play-load');
     el.loadBtn    = document.querySelector('.btn-play-load');
     el.clearBtn   = document.querySelector('.btn-play-clear');
@@ -1503,6 +1591,7 @@
     initAi();
     initCloud();
     initBattlemap();
+    initRevealPanel();
 
     // If the planner or an adventure scene handed off a session, load it.
     var handoff = readSessionHandoff();

--- a/player.html
+++ b/player.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:100,300,400,600,700" rel="stylesheet" type="text/css">
+        <link type="text/css" rel="stylesheet" href="style.css">
+        <title>Player — Dice &amp; Monsters</title>
+    </head>
+
+    <body class="player-page">
+        <nav class="nav">
+            <a href="index.html" class="nav__link">Home</a>
+            <a href="play-ai.html" class="nav__link">Play vs AI</a>
+            <a href="dm.html" class="nav__link">DM</a>
+            <a href="player.html" class="nav__link nav__link--active">Player</a>
+            <a href="character.html" class="nav__link">Characters</a>
+        </nav>
+        <header class="topbar">
+            <h1>Player</h1>
+            <p class="tagline">Your seat at the table — you see only what your character can see.</p>
+        </header>
+
+        <!-- Which character am I playing? -->
+        <section class="player-who">
+            <label class="player-who__label">Play as:
+                <select id="player-self-select" class="player-who__select"></select>
+            </label>
+            <span id="player-conn" class="player-conn"></span>
+        </section>
+
+        <!-- Read-aloud from the DM (scene) -->
+        <section class="card player-scene" id="player-scene" hidden>
+            <h2 id="player-scene-title">Scene</h2>
+            <p id="player-scene-text"></p>
+        </section>
+
+        <!-- Your own character: full detail, only you see it -->
+        <section class="card player-self" id="player-self" hidden>
+            <div class="player-self__head">
+                <h2 id="player-self-name" class="player-self__name">Your character</h2>
+                <a id="player-self-sheet" class="player-self__sheet" href="character.html">Open sheet ↗</a>
+            </div>
+            <div class="player-self__stats">
+                <div class="player-stat player-stat--hp">
+                    <span class="player-stat__label">HP</span>
+                    <div class="player-hp">
+                        <div class="player-hp__bar"><div id="player-hp-fill" class="player-hp__fill"></div></div>
+                        <span id="player-hp-text" class="player-hp__text"></span>
+                    </div>
+                </div>
+                <div class="player-stat"><span class="player-stat__label">AC</span><span id="player-self-ac" class="player-stat__val">—</span></div>
+                <div class="player-stat"><span class="player-stat__label">Init</span><span id="player-self-init" class="player-stat__val">—</span></div>
+            </div>
+            <div class="player-self__conds" id="player-self-conds"></div>
+        </section>
+
+        <!-- The map you have explored (fog of war) -->
+        <section class="battlemap" id="battlemap">
+            <div class="battlemap__head">
+                <h2 class="battlemap__title">Map</h2>
+                <span id="battlemap-dist" class="battlemap__dist"></span>
+            </div>
+            <div class="battlemap__wrap" id="battlemap-wrap">
+                <canvas id="battlemap-canvas" class="battlemap__canvas"></canvas>
+            </div>
+            <div id="battlemap-area" class="bm-areacard" hidden>
+                <button class="bm-areacard__close" type="button" aria-label="Close">✕</button>
+                <h3 class="bm-areacard__title"></h3>
+                <p class="bm-areacard__read"></p>
+            </div>
+            <p class="battlemap__hint">Only the areas your party has discovered are shown. The DM reveals more as you explore.</p>
+        </section>
+
+        <!-- Initiative — appears when combat starts -->
+        <section class="tracker" id="player-tracker" hidden>
+            <div class="tracker__head">
+                <h2 class="tracker__title">Initiative</h2>
+            </div>
+            <div id="player-turn" class="turn"></div>
+        </section>
+
+        <!-- Creatures the DM has revealed (no stats — just what you can see) -->
+        <section class="encounter" id="player-foes-wrap" hidden>
+            <div class="encounter__head">
+                <h2 class="encounter__title">In view</h2>
+            </div>
+            <div id="player-foes" class="player-foes"></div>
+        </section>
+
+        <!-- Messages from the DM -->
+        <section class="ai">
+            <div class="ai__head">
+                <h2 class="ai__title">From the DM</h2>
+            </div>
+            <div id="player-chat" class="ai__output" aria-live="polite"></div>
+            <p class="player-chat__empty" id="player-chat-empty">The DM's narration will appear here.</p>
+        </section>
+
+        <script src="battlemap.js"></script>
+        <script src="visibility.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+        <script src="supabase-config.js"></script>
+        <script src="cloud.js"></script>
+        <script src="auth-ui.js"></script>
+        <script src="player.js"></script>
+    </body>
+</html>

--- a/player.html
+++ b/player.html
@@ -24,6 +24,24 @@
             <p class="tagline">Your seat at the table — you see only what your character can see.</p>
         </header>
 
+        <!-- Join the DM's live session (Supabase; hidden unless configured) -->
+        <section class="player-cloud" id="player-cloud" hidden>
+            <h2 class="player-cloud__title">☁ Join a live game</h2>
+            <p class="player-cloud__hint" id="player-cloud-signin">Sign in (top-right) to join your DM's session.</p>
+            <div class="player-cloud__panel" id="player-cloud-panel" hidden>
+                <div class="player-cloud__row">
+                    <input type="text" id="player-join-code" class="player-cloud__input" placeholder="Invite code from your DM">
+                    <button class="btn-player-join" type="button">Join group</button>
+                </div>
+                <div class="player-cloud__row">
+                    <select id="player-session" class="player-cloud__select"></select>
+                    <button class="btn-player-open" type="button">Open</button>
+                    <button class="btn-player-leave" type="button" hidden>Leave</button>
+                </div>
+                <span id="player-cloud-status" class="player-cloud__status"></span>
+            </div>
+        </section>
+
         <!-- Which character am I playing? -->
         <section class="player-who">
             <label class="player-who__label">Play as:

--- a/player.html
+++ b/player.html
@@ -11,10 +11,13 @@
     <body class="player-page">
         <nav class="nav">
             <a href="index.html" class="nav__link">Home</a>
+            <a href="encounter.html" class="nav__link">Encounter</a>
             <a href="play-ai.html" class="nav__link">Play vs AI</a>
             <a href="dm.html" class="nav__link">DM</a>
             <a href="player.html" class="nav__link nav__link--active">Player</a>
             <a href="character.html" class="nav__link">Characters</a>
+            <a href="groups.html" class="nav__link">Groups</a>
+            <a href="adventure.html" class="nav__link">Adventure</a>
         </nav>
         <header class="topbar">
             <h1>Player</h1>

--- a/player.js
+++ b/player.js
@@ -1,0 +1,265 @@
+/* ============================================================
+   Dice & Monsters — Player Gameplay (player client)
+   ------------------------------------------------------------
+   The screen a player uses when a (human or AI) DM runs the game.
+   It renders ONLY the role-scoped player view: revealed combatants,
+   the fog-limited map, revealed areas (no secret notes), initiative,
+   and the DM's narration.
+
+   ARCHITECTURE RULE: this client never receives hidden information.
+   Its only data source is the already-projected player view that the
+   DM side publishes (localStorage `playerProjection` now; a Supabase
+   player-readable column later). If that isn't present — e.g. you
+   open this page on the same device you're DMing on — it falls back
+   to projecting the local autosave THROUGH visibility.js, so even the
+   fallback strips hidden monsters, traps, DM notes and monster stats
+   before anything is rendered. The full snapshot is never retained.
+
+   Player HP/inventory live on the character sheet (players have no HP
+   counter in combat state), so "your character" is read from the local
+   sheet — it is the player's own data, on the player's own device.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  var PROJECTION_KEY = 'diceAndMonsters.playerProjection'; // safe view published by the DM
+  var AUTOSAVE_KEY   = 'diceAndMonsters.playAutosave';     // full DM snapshot (same-device fallback)
+  var SELF_KEY       = 'diceAndMonsters.playerSelfName';
+  var CHARS_KEY      = 'diceAndMonsters.characters';
+
+  var view = null;        // the ONLY combat state this client holds — already player-safe
+  var selfName = '';
+  var el = {};
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (ch) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+    });
+  }
+  function readLS(key) {
+    try { var raw = window.localStorage.getItem(key); return raw ? JSON.parse(raw) : null; }
+    catch (e) { return null; }
+  }
+
+  /* ---- Source the player-safe view ---------------------------------- */
+  // Prefer the projection the DM published; otherwise project the local
+  // autosave ourselves so a same-device player still sees a safe view.
+  function loadView() {
+    var projected = readLS(PROJECTION_KEY);
+    if (projected && projected.role === 'player') return projected;
+    var raw = readLS(AUTOSAVE_KEY);
+    if (raw && window.Visibility) return window.Visibility.playerView(raw, {});
+    return null;
+  }
+
+  /* ---- Your own character (from the local sheet — your data) --------- */
+  function myToken() {
+    if (!view || !view.combatants) return null;
+    var i, c;
+    for (i = 0; i < view.combatants.length; i++) {
+      c = view.combatants[i];
+      if (c.kind === 'player' && String(c.name).toLowerCase() === selfName.toLowerCase()) return c;
+    }
+    return null;
+  }
+  function mySheet() {
+    var chars = readLS(CHARS_KEY) || [];
+    for (var i = 0; i < chars.length; i++) {
+      if (String(chars[i].name || '').toLowerCase() === selfName.toLowerCase()) return chars[i];
+    }
+    return null;
+  }
+
+  /* ---- Rendering ---------------------------------------------------- */
+  function renderSelfPicker() {
+    var players = (view && view.combatants || []).filter(function (c) { return c.kind === 'player'; });
+    var opts = ['<option value="">— pick your character —</option>'];
+    players.forEach(function (c) {
+      opts.push('<option value="' + esc(c.name) + '"' +
+        (c.name.toLowerCase() === selfName.toLowerCase() ? ' selected' : '') + '>' + esc(c.name) + '</option>');
+    });
+    el.selfSelect.innerHTML = opts.join('');
+  }
+
+  function renderSelf() {
+    var tok = myToken();
+    if (!selfName || !tok) { el.self.hidden = true; return; }
+    el.self.hidden = false;
+    el.selfName.textContent = tok.name;
+
+    var sheet = mySheet();
+    // HP comes from your sheet (players track their own); fall back gracefully.
+    var hp = sheet && sheet.hp ? sheet.hp : null;
+    if (hp && hp.max) {
+      var cur = (hp.current != null ? hp.current : hp.max);
+      var pct = Math.max(0, Math.min(100, Math.round((cur / hp.max) * 100)));
+      el.hpFill.style.width = pct + '%';
+      el.hpFill.className = 'player-hp__fill' + (pct <= 25 ? ' is-low' : (pct <= 50 ? ' is-mid' : ''));
+      el.hpText.textContent = cur + ' / ' + hp.max;
+      el.hpFill.parentNode.parentNode.parentNode.hidden = false;
+    } else {
+      el.hpText.textContent = 'on your sheet';
+      el.hpFill.style.width = '0%';
+    }
+    var ac = (sheet && sheet.ac != null && sheet.ac !== '') ? sheet.ac : (tok.ac != null ? tok.ac : '—');
+    el.selfAc.textContent = ac;
+    el.selfInit.textContent = (tok.initiative != null ? tok.initiative : '—');
+    el.selfSheet.href = 'character.html';
+
+    var conds = tok.conditions || [];
+    el.selfConds.innerHTML = conds.length
+      ? conds.map(function (c) { return '<span class="turn__cond">' + esc(c) + '</span>'; }).join('')
+      : '<span class="player-none">No conditions.</span>';
+  }
+
+  function renderScene() {
+    var sc = view && view.scene;
+    if (!sc || !sc.readAloud) { el.scene.hidden = true; return; }
+    el.scene.hidden = false;
+    el.sceneTitle.textContent = sc.title || 'Scene';
+    el.sceneTitle.hidden = !sc.title;
+    el.sceneText.textContent = sc.readAloud;
+  }
+
+  function renderTurnOrder() {
+    var list = (view && view.combatants || []).filter(function (c) { return c.initiative != null; });
+    list.sort(function (a, b) { return (b.initiative - a.initiative) || (a.id - b.id); });
+    if (!list.length) { el.tracker.hidden = true; return; }
+    el.tracker.hidden = false;
+    el.turn.innerHTML = list.map(function (c) {
+      var active = (view.activeId != null && c.id === view.activeId);
+      var mine = (c.kind === 'player' && c.name.toLowerCase() === selfName.toLowerCase());
+      return '<div class="turn__row' + (active ? ' turn__row--active' : '') +
+        (c.dead ? ' turn__row--dead' : '') + '">' +
+        '<span class="turn__init">' + (c.initiative != null ? c.initiative : '–') + '</span>' +
+        '<span class="turn__name">' + esc(c.name) + (mine ? ' <span class="player-you">you</span>' : '') + '</span>' +
+        '<span class="turn__tag">' + esc(c.kind) + '</span>' +
+      '</div>';
+    }).join('');
+  }
+
+  function renderFoes() {
+    var foes = (view && view.combatants || []).filter(function (c) {
+      return c.kind !== 'player';
+    });
+    if (!foes.length) { el.foesWrap.hidden = true; return; }
+    el.foesWrap.hidden = false;
+    el.foes.innerHTML = foes.map(function (c) {
+      var band = c.dead ? 'down' : (c.health || 'unknown');
+      return '<div class="player-foe' + (c.dead ? ' is-down' : '') + '">' +
+        '<span class="player-foe__dot player-foe__dot--' + esc(c.kind) + '"></span>' +
+        '<span class="player-foe__name">' + esc(c.name) + '</span>' +
+        '<span class="player-foe__band player-foe__band--' + band.replace(/\s+/g, '-') + '">' + esc(band) + '</span>' +
+      '</div>';
+    }).join('');
+  }
+
+  function renderChat() {
+    var lines = (view && view.chatLog || []).filter(function (m) { return m.role === 'dm'; });
+    el.chatEmpty.hidden = lines.length > 0;
+    el.chat.innerHTML = lines.map(function (m) {
+      return '<div class="ai__msg ai__msg--dm"><div class="ai__msg-text">' + esc(m.text) + '</div></div>';
+    }).join('');
+    el.chat.scrollTop = el.chat.scrollHeight;
+  }
+
+  function renderMap() {
+    if (!window.Battlemap) return;
+    window.Battlemap.setMode('view');
+    window.Battlemap.setMap((view && view.map) || null);
+    window.Battlemap.setCombatants((view && view.combatants) || []);
+  }
+
+  function renderAll() {
+    renderSelfPicker();
+    renderScene();
+    renderSelf();
+    renderMap();
+    renderTurnOrder();
+    renderFoes();
+    renderChat();
+    var connected = !!(view && (view.combatants.length || (view.chatLog && view.chatLog.length)));
+    el.conn.textContent = connected ? '● live' : 'Waiting for the DM to start a session…';
+    el.conn.className = 'player-conn' + (connected ? ' is-live' : '');
+  }
+
+  /* ---- Live refresh (poll + cross-tab storage events) --------------- */
+  function refresh() {
+    var next = loadView();
+    view = next || { role: 'player', combatants: [], activeId: null, scene: null, chatLog: [], map: null };
+    renderAll();
+  }
+
+  function initBattlemap() {
+    var BM = window.Battlemap, canvas = document.querySelector('#battlemap-canvas');
+    if (!BM || !canvas) return;
+    BM.init({
+      canvas: canvas,
+      wrap: document.querySelector('#battlemap-wrap'),
+      distanceEl: document.querySelector('#battlemap-dist'),
+      onAreaSelect: showAreaCard
+    });
+    BM.setMode('view');
+    el.areaCard = document.querySelector('#battlemap-area');
+    if (el.areaCard) {
+      el.areaCard.querySelector('.bm-areacard__close')
+        .addEventListener('click', function () { el.areaCard.hidden = true; });
+    }
+  }
+
+  // Players only ever see an area's read-aloud text — the projection
+  // already stripped the DM notes, so there is nothing secret to leak.
+  function showAreaCard(area) {
+    if (!el.areaCard) return;
+    if (!area) { el.areaCard.hidden = true; return; }
+    el.areaCard.querySelector('.bm-areacard__title').textContent =
+      'Area ' + area.n + (area.title ? ' — ' + area.title : '');
+    var read = el.areaCard.querySelector('.bm-areacard__read');
+    read.textContent = area.read || '';
+    read.hidden = !area.read;
+    el.areaCard.hidden = false;
+  }
+
+  function init() {
+    el.selfSelect = document.querySelector('#player-self-select');
+    el.conn       = document.querySelector('#player-conn');
+    el.scene      = document.querySelector('#player-scene');
+    el.sceneTitle = document.querySelector('#player-scene-title');
+    el.sceneText  = document.querySelector('#player-scene-text');
+    el.self       = document.querySelector('#player-self');
+    el.selfName   = document.querySelector('#player-self-name');
+    el.selfSheet  = document.querySelector('#player-self-sheet');
+    el.hpFill     = document.querySelector('#player-hp-fill');
+    el.hpText     = document.querySelector('#player-hp-text');
+    el.selfAc     = document.querySelector('#player-self-ac');
+    el.selfInit   = document.querySelector('#player-self-init');
+    el.selfConds  = document.querySelector('#player-self-conds');
+    el.tracker    = document.querySelector('#player-tracker');
+    el.turn       = document.querySelector('#player-turn');
+    el.foesWrap   = document.querySelector('#player-foes-wrap');
+    el.foes       = document.querySelector('#player-foes');
+    el.chat       = document.querySelector('#player-chat');
+    el.chatEmpty  = document.querySelector('#player-chat-empty');
+
+    try { selfName = window.localStorage.getItem(SELF_KEY) || ''; } catch (e) { selfName = ''; }
+
+    el.selfSelect.addEventListener('change', function () {
+      selfName = el.selfSelect.value || '';
+      try { window.localStorage.setItem(SELF_KEY, selfName); } catch (e) { /* ignore */ }
+      renderSelf();
+      renderTurnOrder();
+    });
+
+    initBattlemap();
+    refresh();
+
+    // Live updates: cross-tab storage events (instant) + a slow poll.
+    window.addEventListener('storage', function (ev) {
+      if (!ev || ev.key === PROJECTION_KEY || ev.key === AUTOSAVE_KEY || ev.key === null) refresh();
+    });
+    window.setInterval(refresh, 1500);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/player.js
+++ b/player.js
@@ -31,6 +31,13 @@
   var selfName = '';
   var el = {};
 
+  // Cloud (live multiplayer) state. When a cloud session is open, its
+  // already-sanitized `view` is the source of truth; the full DM state is
+  // never fetched here (RLS forbids it), so nothing hidden can arrive.
+  var cloudView = null;
+  var cloudSessionId = null;
+  var cloudChannel = null;
+
   function esc(s) {
     return String(s == null ? '' : s).replace(/[&<>"']/g, function (ch) {
       return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
@@ -42,9 +49,11 @@
   }
 
   /* ---- Source the player-safe view ---------------------------------- */
-  // Prefer the projection the DM published; otherwise project the local
-  // autosave ourselves so a same-device player still sees a safe view.
+  // Source priority: a live cloud session (already sanitized server-side) →
+  // the DM's locally-published projection → projecting the local autosave
+  // ourselves (same-device demo). Every path yields a player-safe view.
   function loadView() {
+    if (cloudView) return cloudView;
     var projected = readLS(PROJECTION_KEY);
     if (projected && projected.role === 'player') return projected;
     var raw = readLS(AUTOSAVE_KEY);
@@ -220,6 +229,88 @@
     el.areaCard.hidden = false;
   }
 
+  /* ---- Cloud lobby: join the DM's live session --------------------- */
+  function pcStatus(t) { if (el.pcStatus) el.pcStatus.textContent = t || ''; }
+
+  function initCloud() {
+    el.cloud = document.querySelector('#player-cloud');
+    if (!el.cloud || !window.Cloud || !Cloud.available()) return;   // no cloud → local only
+    el.cloud.hidden = false;
+    el.pcSignin  = document.querySelector('#player-cloud-signin');
+    el.pcPanel   = document.querySelector('#player-cloud-panel');
+    el.pcCode    = document.querySelector('#player-join-code');
+    el.pcSession = document.querySelector('#player-session');
+    el.pcStatus  = document.querySelector('#player-cloud-status');
+    el.pcOpen    = document.querySelector('.btn-player-open');
+    el.pcLeave   = document.querySelector('.btn-player-leave');
+
+    document.querySelector('.btn-player-join').addEventListener('click', doJoin);
+    el.pcOpen.addEventListener('click', function () { if (el.pcSession.value) openSession(el.pcSession.value); });
+    el.pcLeave.addEventListener('click', leaveSession);
+
+    var deepLink = null;
+    try { deepLink = new URLSearchParams(window.location.search).get('s'); } catch (e) { /* ignore */ }
+
+    Cloud.init();
+    Cloud.onAuth(function (user) {
+      var signedIn = !!user;
+      if (el.pcSignin) el.pcSignin.hidden = signedIn;
+      if (el.pcPanel) el.pcPanel.hidden = !signedIn;
+      if (signedIn) {
+        refreshSessions(function () { if (deepLink) { openSession(deepLink); deepLink = null; } });
+      }
+    });
+  }
+  function refreshSessions(done) {
+    Cloud.listPlayerViews().then(function (res) {
+      if (res.error) { pcStatus(res.error.message); return; }
+      var rows = res.data || [];
+      el.pcSession.innerHTML = rows.length
+        ? rows.map(function (r) { return '<option value="' + r.session_id + '">' + esc(r.title || 'Untitled') + '</option>'; }).join('')
+        : '<option value="">No shared sessions yet</option>';
+      el.pcSession.disabled = !rows.length;
+      if (done) done();
+    });
+  }
+  function doJoin() {
+    var code = (el.pcCode.value || '').trim();
+    if (!code) { pcStatus('Enter the invite code from your DM.'); return; }
+    pcStatus('Joining…');
+    Cloud.joinGroup(code).then(function (res) {
+      if (res.error) { pcStatus(res.error.message); return; }
+      el.pcCode.value = ''; pcStatus('Joined. Pick the session below.');
+      refreshSessions();
+    });
+  }
+  function openSession(id) {
+    if (!id) return;
+    pcStatus('Opening…');
+    Cloud.loadPlayerView(id).then(function (res) {
+      if (res.error) { pcStatus('Could not open: ' + res.error.message); return; }
+      if (!res.data) { pcStatus('Not available — ask your DM to share, and make sure you joined the group.'); return; }
+      cloudSessionId = id;
+      cloudView = res.data.view || null;
+      subscribeCloud(id);
+      pcStatus('Live: “' + (res.data.title || 'session') + '”.');
+      if (el.pcLeave) el.pcLeave.hidden = false;
+      refresh();
+    });
+  }
+  function subscribeCloud(id) {
+    if (cloudChannel) { Cloud.unsubscribe(cloudChannel); cloudChannel = null; }
+    cloudChannel = Cloud.subscribePlayerView(id, function (row) {
+      cloudView = row ? row.view : null;
+      refresh();
+    });
+  }
+  function leaveSession() {
+    if (cloudChannel) { Cloud.unsubscribe(cloudChannel); cloudChannel = null; }
+    cloudSessionId = null; cloudView = null;
+    if (el.pcLeave) el.pcLeave.hidden = true;
+    pcStatus('Left the session.');
+    refresh();
+  }
+
   function init() {
     el.selfSelect = document.querySelector('#player-self-select');
     el.conn       = document.querySelector('#player-conn');
@@ -251,6 +342,7 @@
     });
 
     initBattlemap();
+    initCloud();
     refresh();
 
     // Live updates: cross-tab storage events (instant) + a slow poll.

--- a/style.css
+++ b/style.css
@@ -1939,3 +1939,12 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 }
 .btn-marker-reveal { border-color: #27632f !important; color: #27ae60 !important; }
 .btn-marker-remove { border-color: #7a2318 !important; color: #c0392b !important; }
+
+/* ============================================================
+   Role-driven layout: each seat shows only its own components.
+   role-ai  = Play vs AI DM (AI is the DM; human is a player)
+   role-dm  = human DM console
+   ============================================================ */
+.role-dm #ai-dm { display: none; }                 /* human DM: no AI DM panel */
+.role-ai #reveal-panel { display: none; }          /* AI is the DM: no manual reveal panel */
+.role-ai .item__reveal { display: none; }          /* …nor per-creature reveal toggles */

--- a/style.css
+++ b/style.css
@@ -1948,3 +1948,24 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 .role-dm #ai-dm { display: none; }                 /* human DM: no AI DM panel */
 .role-ai #reveal-panel { display: none; }          /* AI is the DM: no manual reveal panel */
 .role-ai .item__reveal { display: none; }          /* …nor per-creature reveal toggles */
+
+/* Player cloud lobby (player.html) */
+.player-cloud {
+    max-width: 960px; margin: 0 auto 14px; padding: 14px 16px;
+    background: #1d2029; border: 1px solid #2c3140; border-radius: 12px;
+}
+.player-cloud__title { font-size: 16px; color: #4aa3df; margin-bottom: 8px; }
+.player-cloud__hint { color: #9aa3b2; font-size: 13px; }
+.player-cloud__row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; align-items: center; }
+.player-cloud__input, .player-cloud__select {
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140;
+    border-radius: 6px; padding: 7px 10px; font-size: 14px;
+}
+.player-cloud__select { min-width: 200px; }
+.player-cloud__row button {
+    background: #2980b9; color: #fff; border: none; border-radius: 6px;
+    padding: 7px 14px; font-size: 13px; cursor: pointer;
+}
+.player-cloud__row button:hover { background: #3a91cc; }
+.btn-player-leave { background: #12141a !important; border: 1px solid #2c3140 !important; color: #cfd6e2 !important; }
+.player-cloud__status { display: block; margin-top: 8px; color: #8a93a6; font-size: 13px; }

--- a/style.css
+++ b/style.css
@@ -1909,3 +1909,33 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 .item__reveal.is-shown { color: #27ae60; border-color: #27632f; }
 .item__reveal.is-hidden { color: #c0392b; border-color: #7a2318; }
 .item__reveal:hover { background: #262b36; }
+
+/* Fog brush segmented control + marker tools (DM "Players see" panel). */
+.reveal__seg { display: inline-flex; border: 1px solid #2c3140; border-radius: 6px; overflow: hidden; }
+.reveal__seg button { border: none; border-right: 1px solid #2c3140; border-radius: 0; background: #12141a; }
+.reveal__seg button:last-child { border-right: none; }
+.reveal__seg button.is-active { background: #2980b9; color: #fff; }
+.btn-marker { font-size: 13px; }
+
+/* Marker editor card (over the battlemap) */
+.bm-markercard {
+    position: relative; margin-top: 10px; padding: 12px 14px;
+    background: #1d2029; border: 1px solid #2c3140; border-radius: 10px; max-width: 460px;
+}
+.bm-markercard__close {
+    position: absolute; top: 8px; right: 8px; background: none; border: none;
+    color: #8a93a6; font-size: 15px; cursor: pointer;
+}
+.bm-markercard__title { font-size: 15px; color: #e1b12c; margin-bottom: 10px; padding-right: 20px; }
+.bm-markercard__field { display: block; color: #9aa3b2; font-size: 12px; margin-bottom: 8px; }
+.bm-markercard__input {
+    display: block; width: 100%; margin-top: 4px; box-sizing: border-box;
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140; border-radius: 6px; padding: 7px 9px; font-size: 14px;
+}
+.bm-markercard__actions { display: flex; gap: 8px; margin-top: 6px; }
+.bm-markercard__actions button {
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140;
+    border-radius: 6px; padding: 6px 12px; font-size: 13px; cursor: pointer;
+}
+.btn-marker-reveal { border-color: #27632f !important; color: #27ae60 !important; }
+.btn-marker-remove { border-color: #7a2318 !important; color: #c0392b !important; }

--- a/style.css
+++ b/style.css
@@ -1821,3 +1821,91 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
     line-height: 1;
 }
 .bm-modal__close:hover { background: #4a5162; }
+
+/* ============================================================
+   Player Gameplay view (player.html) — role-scoped, fog of war.
+   Reuses .nav/.topbar/.card/.turn/.ai__msg; adds the player bits.
+   ============================================================ */
+.player-who {
+    max-width: 960px; margin: 0 auto 14px; padding: 0 16px;
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+}
+.player-who__label { color: #cfd6e2; font-size: 14px; }
+.player-who__select {
+    margin-left: 8px; background: #12141a; color: #e6e6e6;
+    border: 1px solid #2c3140; border-radius: 6px; padding: 6px 10px; font-size: 14px;
+}
+.player-conn { font-size: 13px; color: #7a8090; }
+.player-conn.is-live { color: #27ae60; }
+
+.player-scene { max-width: 960px; margin: 0 auto 14px; }
+.player-scene p { color: #cfd6e2; line-height: 1.55; white-space: pre-wrap; }
+
+.player-self { max-width: 960px; margin: 0 auto 14px; }
+.player-self__head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.player-self__name { font-size: 20px; color: #fff; }
+.player-self__sheet { color: #4aa3df; font-size: 13px; text-decoration: none; }
+.player-self__sheet:hover { text-decoration: underline; }
+.player-self__stats { display: flex; gap: 22px; align-items: center; margin: 12px 0; flex-wrap: wrap; }
+.player-stat { display: flex; flex-direction: column; gap: 4px; min-width: 54px; }
+.player-stat--hp { flex: 1; min-width: 200px; }
+.player-stat__label { font-size: 11px; text-transform: uppercase; letter-spacing: .6px; color: #8a93a6; }
+.player-stat__val { font-size: 22px; font-weight: 700; color: #fff; }
+.player-hp { display: flex; align-items: center; gap: 10px; }
+.player-hp__bar { flex: 1; height: 14px; background: #12141a; border: 1px solid #2c3140; border-radius: 8px; overflow: hidden; }
+.player-hp__fill { height: 100%; width: 0; background: #27ae60; transition: width .3s ease; }
+.player-hp__fill.is-mid { background: #e1b12c; }
+.player-hp__fill.is-low { background: #c0392b; }
+.player-hp__text { font-size: 14px; color: #cfd6e2; white-space: nowrap; }
+.player-self__conds { display: flex; flex-wrap: wrap; gap: 6px; }
+.player-none { color: #6c7589; font-style: italic; font-size: 13px; }
+.player-you { font-size: 11px; color: #4aa3df; text-transform: uppercase; letter-spacing: .5px; }
+
+.player-foes { display: flex; flex-direction: column; gap: 8px; }
+.player-foe {
+    display: flex; align-items: center; gap: 10px;
+    background: #12141a; border: 1px solid #2c3140; border-radius: 8px; padding: 8px 12px;
+}
+.player-foe.is-down { opacity: .5; text-decoration: line-through; }
+.player-foe__dot { width: 12px; height: 12px; border-radius: 50%; flex: none; }
+.player-foe__dot--monster { background: #c0392b; }
+.player-foe__dot--npc { background: #9b59b6; }
+.player-foe__name { flex: 1; color: #fff; font-weight: 600; }
+.player-foe__band { font-size: 12px; text-transform: uppercase; letter-spacing: .5px; color: #8a93a6; }
+.player-foe__band--healthy { color: #27ae60; }
+.player-foe__band--wounded { color: #e1b12c; }
+.player-foe__band--bloodied { color: #e67e22; }
+.player-foe__band--near-death { color: #c0392b; }
+.player-foe__band--down { color: #6c7589; }
+.player-chat__empty { color: #6c7589; font-style: italic; font-size: 13px; }
+.player-chat__empty[hidden] { display: none; }
+
+/* ============================================================
+   DM visibility controls (play.html "Players see" panel) +
+   per-creature reveal toggle.
+   ============================================================ */
+.reveal {
+    max-width: 960px; margin: 0 auto 18px; padding: 14px 16px;
+    background: #1d2029; border: 1px solid #2c3140; border-radius: 12px;
+}
+.reveal__head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+.reveal__title { font-size: 16px; color: #e1b12c; }
+.reveal__open { color: #4aa3df; font-size: 13px; text-decoration: none; }
+.reveal__open:hover { text-decoration: underline; }
+.reveal__row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 8px; }
+.reveal__toggle { color: #cfd6e2; font-size: 14px; display: flex; align-items: center; gap: 6px; }
+.reveal__label { color: #8a93a6; font-size: 13px; text-transform: uppercase; letter-spacing: .5px; }
+.reveal__hint { color: #6c7589; font-size: 12px; font-style: italic; }
+.reveal button {
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140;
+    border-radius: 6px; padding: 6px 12px; font-size: 13px; cursor: pointer;
+}
+.reveal button:hover { background: #262b36; border-color: #3b4150; }
+
+.item__reveal {
+    margin-left: auto; background: #12141a; border: 1px solid #2c3140;
+    border-radius: 6px; padding: 3px 9px; font-size: 12px; cursor: pointer; white-space: nowrap;
+}
+.item__reveal.is-shown { color: #27ae60; border-color: #27632f; }
+.item__reveal.is-hidden { color: #c0392b; border-color: #7a2318; }
+.item__reveal:hover { background: #262b36; }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -219,13 +219,13 @@ create index if not exists play_sessions_group_idx on play_sessions(group_id);
 
 alter table play_sessions enable row level security;
 
--- Read your own sessions, plus shared sessions in groups you belong to.
+-- Owner-only. The full session `state` holds hidden monsters, DM notes,
+-- traps and the AI transcript, so it must NEVER be readable by players —
+-- Postgres RLS can't hide a single column, so players don't read this row
+-- at all. They read the sanitized projection in play_player_views instead.
 drop policy if exists play_select on play_sessions;
 create policy play_select on play_sessions
-  for select to authenticated using (
-    owner = auth.uid()
-    or (shared = true and group_id is not null and is_group_member(group_id))
-  );
+  for select to authenticated using ( owner = auth.uid() );
 
 -- Only the owner (the DM) creates / edits / deletes a session.
 drop policy if exists play_insert on play_sessions;
@@ -240,9 +240,54 @@ drop policy if exists play_delete on play_sessions;
 create policy play_delete on play_sessions
   for delete to authenticated using (owner = auth.uid());
 
--- Realtime: let players watch the DM's session update live.
+-- Realtime: let the DM's own devices watch their session update live.
 -- (Safe to run once; if it says the table is already a member, ignore it.)
 alter publication supabase_realtime add table play_sessions;
+
+-- ---- Player projection (the role-scoped view players receive) ----
+-- The DM writes `view` from Visibility.playerView(): revealed combatants
+-- only, the fog-limited map, revealed non-secret areas/markers, DM
+-- narration — and nothing else. Group members READ this; the owner writes
+-- it. This table, not play_sessions, is what a player client subscribes to,
+-- so hidden information is never sent to a player at all (the fundamental
+-- rule, enforced in the database).
+create table if not exists play_player_views (
+  session_id uuid primary key references play_sessions(id) on delete cascade,
+  owner      uuid not null references auth.users(id) on delete cascade,
+  group_id   uuid references groups(id) on delete set null,
+  title      text,
+  view       jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists play_player_views_group_idx on play_player_views(group_id);
+create index if not exists play_player_views_owner_idx on play_player_views(owner);
+
+alter table play_player_views enable row level security;
+
+-- The owner (DM) writes it; the owner and any member of the attached group
+-- may read it. There is nothing secret here to protect column-wise.
+drop policy if exists ppv_select on play_player_views;
+create policy ppv_select on play_player_views
+  for select to authenticated using (
+    owner = auth.uid()
+    or (group_id is not null and is_group_member(group_id))
+  );
+
+drop policy if exists ppv_insert on play_player_views;
+create policy ppv_insert on play_player_views
+  for insert to authenticated with check (owner = auth.uid());
+
+drop policy if exists ppv_update on play_player_views;
+create policy ppv_update on play_player_views
+  for update to authenticated using (owner = auth.uid());
+
+drop policy if exists ppv_delete on play_player_views;
+create policy ppv_delete on play_player_views
+  for delete to authenticated using (owner = auth.uid());
+
+-- Realtime: players watch the projection update live as the DM plays.
+alter publication supabase_realtime add table play_player_views;
 
 -- ============================================================
 -- User collections — your characters / adventures / encounters

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -241,8 +241,14 @@ create policy play_delete on play_sessions
   for delete to authenticated using (owner = auth.uid());
 
 -- Realtime: let the DM's own devices watch their session update live.
--- (Safe to run once; if it says the table is already a member, ignore it.)
-alter publication supabase_realtime add table play_sessions;
+-- Idempotent: adding a table that's already in the publication raises
+-- 42710 (duplicate_object), which would abort the whole script on a
+-- re-run, so we swallow just that error.
+do $$
+begin
+  alter publication supabase_realtime add table play_sessions;
+exception when duplicate_object then null;
+end $$;
 
 -- ---- Player projection (the role-scoped view players receive) ----
 -- The DM writes `view` from Visibility.playerView(): revealed combatants
@@ -287,7 +293,12 @@ create policy ppv_delete on play_player_views
   for delete to authenticated using (owner = auth.uid());
 
 -- Realtime: players watch the projection update live as the DM plays.
-alter publication supabase_realtime add table play_player_views;
+-- Idempotent (see the note on play_sessions above).
+do $$
+begin
+  alter publication supabase_realtime add table play_player_views;
+exception when duplicate_object then null;
+end $$;
 
 -- ============================================================
 -- User collections — your characters / adventures / encounters

--- a/visibility.js
+++ b/visibility.js
@@ -128,6 +128,13 @@
       if (a.hidden || !a.revealed) return;
       out.areas.push({ n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '' });
     });
+    // Markers (traps / secret doors / treasure): an unrevealed one is never
+    // sent at all, and the DM's secret `note` is stripped from revealed ones.
+    out.markers = [];
+    (map.markers || []).forEach(function (mk) {
+      if (!mk.revealed) return;
+      out.markers.push({ id: mk.id, x: mk.x, y: mk.y, type: mk.type, label: mk.label || '' });
+    });
     return out;
   }
 

--- a/visibility.js
+++ b/visibility.js
@@ -1,0 +1,176 @@
+/* ============================================================
+   Dice & Monsters — Role-based visibility (shared core)
+   ------------------------------------------------------------
+   The single source of truth for "who is allowed to see what".
+
+   FUNDAMENTAL ARCHITECTURE RULE (see CLAUDE.md):
+     Hidden information must never be *sent* to a player client and
+     then merely hidden in the UI. It must not leave the DM's seat
+     at all. This module is where that rule is enforced: it takes a
+     full DM snapshot and returns a role-scoped snapshot that
+     physically omits everything the role may not know.
+
+   Pure: no DOM, no network. Both the DM console (which computes the
+   player projection before syncing it) and any local preview use it.
+
+   Roles:
+     - 'dm'      → the full snapshot (human DM / AI DM see everything).
+     - 'player'  → only revealed combatants, revealed & unlocked map
+                   areas (no secret DM notes), the fog-limited map,
+                   the player's own character in full, and DM
+                   narration. No hidden monsters, traps, secret rooms,
+                   DM notes, monster statistics, AI tool state, or the
+                   raw mechanical combat log.
+
+   Snapshot shape (from play.js snapshot()):
+     { v, combatants[], activeId, log[], scene, chatLog[], aiMessages, map }
+   ============================================================ */
+(function () {
+  'use strict';
+
+  /* ---- Coarse HP banding: a player may see that a revealed monster
+     is bloodied, never its HP total or AC/attacks. ---- */
+  function band(hp, maxHp, dead) {
+    if (dead) return 'down';
+    if (hp == null || maxHp == null || maxHp <= 0) return 'unknown';
+    var r = hp / maxHp;
+    if (r <= 0.1) return 'near death';
+    if (r <= 0.5) return 'bloodied';
+    if (r < 1) return 'wounded';
+    return 'healthy';
+  }
+
+  // Split a scene's text into read-aloud vs. DM-only notes (mirrors
+  // ai-context.js so we don't depend on its load order).
+  function readAloudOf(scene) {
+    if (!scene) return null;
+    var text = String(scene.text || '');
+    var m = /dm notes?:/i.exec(text);
+    var read = m ? text.slice(0, m.index).trim() : text;
+    return { title: scene.title || '', readAloud: read };
+  }
+
+  function isHidden(c) { return !!(c && c.hidden); }
+
+  // True when this combatant is the viewing player's own character.
+  function isSelf(c, opts) {
+    if (!opts) return false;
+    if (opts.selfId != null && c.id != null) return c.id === opts.selfId;
+    if (opts.selfName) {
+      return String(c.name || '').toLowerCase() === String(opts.selfName).toLowerCase();
+    }
+    return false;
+  }
+
+  // A single combatant, reduced to what a player may receive.
+  //   - own character: full detail (HP, AC, attacks) — it's theirs.
+  //   - other PCs: name/position/conditions, but no HP numbers
+  //     (each player tracks their own).
+  //   - revealed monsters/NPCs: name/position/conditions + a coarse
+  //     health band only — never HP totals, AC, or attack stats.
+  function playerCombatant(c, opts) {
+    var v = {
+      id: c.id,
+      name: c.name,
+      kind: c.kind,
+      dead: !!c.dead,
+      conditions: (c.conditions || []).slice(),
+      initiative: (c.initiative == null ? null : c.initiative),
+      x: (c.x == null ? null : c.x),
+      y: (c.y == null ? null : c.y)
+    };
+    if (isSelf(c, opts)) {
+      v.self = true;
+      v.hp = c.hp; v.maxHp = c.maxHp; v.ac = c.ac;
+      if (c.attacks) v.attacks = c.attacks;
+    } else if (c.kind === 'player') {
+      // A fellow player: they own their HP; we don't expose numbers.
+      v.ac = (c.ac == null ? null : c.ac);
+    } else {
+      // Revealed monster / NPC: coarse band only, no statistics.
+      v.health = band(c.hp, c.maxHp, c.dead);
+    }
+    return v;
+  }
+
+  // The map, fog- and secret-limited. When fog is on, unrevealed
+  // terrain and the background image are stripped at the data level
+  // (not sent), so the player client cannot reconstruct them.
+  function playerMap(map) {
+    if (!map) return null;
+    var fog = !!map.fog;
+    var out = {
+      v: 1,
+      grid: (map.grid === 'hex' ? 'hex' : 'square'),
+      cols: map.cols, rows: map.rows,
+      fog: fog,
+      terrain: {},
+      areas: [],
+      starts: null,          // start zones are DM prep — never sent
+      bg: fog ? null : (map.bg || null)
+    };
+    var revealed = map.revealed || {};
+    var k;
+    if (fog) {
+      out.revealed = {};
+      for (k in revealed) if (revealed.hasOwnProperty(k)) out.revealed[k] = 1;
+      var terrain = map.terrain || {};
+      for (k in terrain) {
+        if (terrain.hasOwnProperty(k) && revealed[k]) out.terrain[k] = terrain[k];
+      }
+    } else {
+      var t = map.terrain || {};
+      for (k in t) if (t.hasOwnProperty(k)) out.terrain[k] = t[k];
+    }
+    // Areas: only those the DM has revealed and not marked hidden, and
+    // with secret DM notes stripped out entirely.
+    (map.areas || []).forEach(function (a) {
+      if (a.hidden || !a.revealed) return;
+      out.areas.push({ n: a.n, x: a.x, y: a.y, title: a.title || '', read: a.read || '' });
+    });
+    return out;
+  }
+
+  /* ---- The DM view: everything, unchanged. ---- */
+  function dmView(snapshot) { return snapshot; }
+
+  /* ---- The player view: only what the character may know. ---- */
+  function playerView(snapshot, opts) {
+    snapshot = snapshot || {};
+    opts = opts || {};
+    var combatants = (snapshot.combatants || [])
+      .filter(function (c) { return !isHidden(c); })
+      .map(function (c) { return playerCombatant(c, opts); });
+
+    // Only DM narration reaches players — never the raw mechanical
+    // combat log (it references monster HP) or the AI tool transcript.
+    var chatLog = (snapshot.chatLog || []).filter(function (m) {
+      return m && m.role === 'dm';
+    }).map(function (m) { return { role: 'dm', text: m.text }; });
+
+    return {
+      v: 1,
+      role: 'player',
+      combatants: combatants,
+      activeId: (snapshot.activeId == null ? null : snapshot.activeId),
+      scene: readAloudOf(snapshot.scene),
+      chatLog: chatLog,
+      map: playerMap(snapshot.map)
+      // Deliberately omitted: log, aiMessages, hidden combatants,
+      // start zones, secret areas, DM notes, monster statistics.
+    };
+  }
+
+  // Convenience: project a snapshot for an arbitrary role.
+  function viewFor(role, snapshot, opts) {
+    return role === 'player' ? playerView(snapshot, opts) : dmView(snapshot);
+  }
+
+  window.Visibility = {
+    dmView: dmView,
+    playerView: playerView,
+    viewFor: viewFor,
+    band: band,
+    readAloudOf: readAloudOf
+  };
+})();


### PR DESCRIPTION
## Summary

Splits gameplay into three distinct modes — **Play vs AI DM**, **DM Console**, and **Player** — each seeing only the information its role is allowed to know. The keystone is a **fundamental architecture rule**: hidden information is never *sent* to a player client and merely hidden in the UI — it never leaves the DM's seat. That rule is now enforced at three levels: the data model, a pure projection layer, and the network (separate Supabase tables + RLS).

## What's included

**Role-based visibility (the keystone)**
- New `visibility.js` (`window.Visibility`) — pure. `playerView(snapshot)` projects a full DM snapshot down to only what a player may see: revealed combatants, the fog-limited map, revealed non-secret areas/markers, DM narration. It strips hidden creatures, DM notes, monster statistics (→ a coarse `health` band), start zones, the raw combat log, and the AI transcript.
- `combat-engine.js`: `hidden` flag on combatants + stable ids in (de)serialize.

**Three modes (separate views)**
- `player.html` + `player.js` — the separate Player client; consumes only the sanitized projection, never the full state.
- `play-ai.html` (AI is the DM) and `dm.html` (human DM) share `play.js` via `?role=`; a body role-class drives per-seat layout (AI mode hides the manual reveal panel; DM mode hides the AI panel). Home + nav updated to the three modes.

**Fog of war & DM reveal**
- `battlemap.js`: fog of war (`map.fog`, `map.revealed`), per-area `hidden`/`revealed`, and trap/secret/treasure **markers** (DM-only, with a secret note, until revealed).
- DM "👁 Players see" panel: fog toggle, reveal-whole-map, a **reveal/hide fog brush** (paint cells in play mode), **auto-reveal around player tokens** as they move, per-creature 👁/🙈 toggles, and a marker editor.

**Live multiplayer (split-sync)**
- Postgres RLS can't hide a single column, so the full state and the player projection are **separate tables**: `play_sessions` (full DM state, **owner-only**) and `play_player_views` (the sanitized projection, group-readable, Realtime). `supabase/schema.sql` updated and re-runnable.
- `cloud.js`: `savePlayerView` / `loadPlayerView` / `listPlayerViews` / `subscribePlayerView`.
- DM publishes `Visibility.playerView(snapshot)` to `play_player_views` on share/autosave; the invite panel shows the group code + a `player.html?s=<id>` link.
- Players get a lobby (join by code, pick a shared session) and a `?s=<id>` deep link; the live source is the subscribed, already-sanitized view.

## Verification

Cloud/AI can't reach real services from the sandbox, so those paths are verified via stubs + graceful-degradation checks:
- `node --check` on all changed JS.
- **32/32** assertions in a visibility-projection unit test (hidden monsters, DM notes, monster stats, unrevealed areas/markers, start zones, raw log, AI transcript all absent).
- A cloud-split unit test (stubbed client) proving full state → `play_sessions` and the sanitized view → `play_player_views` — different tables, no hidden data in the view.
- Playwright: the Player and DM pages render correctly, hide all seeded secrets, apply the right per-role layout, and produce no runtime errors; pages degrade gracefully when cloud is unconfigured.

## Note for deploy

Re-run `supabase/schema.sql` in the Supabase SQL Editor (idempotent) to create `play_player_views` and tighten the session policy for the multiplayer split. Details in `SUPABASE.md` / `CLAUDE.md`.

This branch also carries earlier battlemap/encounter-map commits that were not yet on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMs7NRa7kR15MvufX8piKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMs7NRa7kR15MvufX8piKD)_