### PR TITLE
Show a player's roll modifiers on their Game Session card

### DIFF
--- a/Dice&Monsters.js
+++ b/Dice&Monsters.js
@@ -154,10 +154,63 @@
     };
   }
 
+  // 5e skills keyed to their ability — so a sheet imported here carries its
+  // roll modifiers through the handoff and the Game Session can show them as
+  // a quick reference (e.g. when the AI DM asks for an Investigation check).
+  var SHEET_SKILLS = [
+    { key: 'acrobatics', label: 'Acrobatics', ability: 'dex' },
+    { key: 'animalHandling', label: 'Animal Handling', ability: 'wis' },
+    { key: 'arcana', label: 'Arcana', ability: 'int' },
+    { key: 'athletics', label: 'Athletics', ability: 'str' },
+    { key: 'deception', label: 'Deception', ability: 'cha' },
+    { key: 'history', label: 'History', ability: 'int' },
+    { key: 'insight', label: 'Insight', ability: 'wis' },
+    { key: 'intimidation', label: 'Intimidation', ability: 'cha' },
+    { key: 'investigation', label: 'Investigation', ability: 'int' },
+    { key: 'medicine', label: 'Medicine', ability: 'wis' },
+    { key: 'nature', label: 'Nature', ability: 'int' },
+    { key: 'perception', label: 'Perception', ability: 'wis' },
+    { key: 'performance', label: 'Performance', ability: 'cha' },
+    { key: 'persuasion', label: 'Persuasion', ability: 'cha' },
+    { key: 'religion', label: 'Religion', ability: 'int' },
+    { key: 'sleightOfHand', label: 'Sleight of Hand', ability: 'dex' },
+    { key: 'stealth', label: 'Stealth', ability: 'dex' },
+    { key: 'survival', label: 'Survival', ability: 'wis' }
+  ];
+  var ABIL_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
+  // Precompute d20 roll modifiers (ability checks, saves, skills, passive
+  // Perception) from a sheet. Prep only carries this data; the Game Session
+  // renders it. Mirrors the engine's sheetChecks so both entry paths match.
+  function sheetChecks(sheet) {
+    var abilities = sheet.abilities || {};
+    var skillProf = sheet.skillProf || {};
+    var saveProf = sheet.saveProf || {};
+    var pb = 2 + Math.floor(((sheet.level || 1) - 1) / 4);
+    function mod(k) { return abilityMod(abilities[k] == null ? 10 : abilities[k]); }
+    return {
+      prof: pb, init: sheetInitMod(sheet),
+      passive: 10 + mod('wis') + (skillProf['perception'] ? pb : 0),
+      abilities: ABIL_KEYS.map(function (k) {
+        return { key: k, score: (abilities[k] == null ? 10 : abilities[k]), mod: mod(k) };
+      }),
+      saves: ABIL_KEYS.map(function (k) {
+        var prof = !!saveProf[k];
+        return { key: k, prof: prof, mod: mod(k) + (prof ? pb : 0) };
+      }),
+      skills: SHEET_SKILLS.map(function (s) {
+        var prof = !!skillProf[s.key];
+        return { key: s.key, label: s.label, ability: s.ability, prof: prof, mod: mod(s.ability) + (prof ? pb : 0) };
+      })
+    };
+  }
+
   // PC sheet -> player combatant (AC + initiative only; no HP).
   function createPlayerFromSheet(sheet) {
-    return createPlayer(sheet.name || 'Player', sheetInitMod(sheet),
+    var c = createPlayer(sheet.name || 'Player', sheetInitMod(sheet),
       (sheet.ac != null && sheet.ac !== '' ? sheet.ac : null));
+    c.checks = sheetChecks(sheet);
+    return c;
   }
 
   // NPC sheet -> DM-controlled combatant with HP, AC and attacks.
@@ -169,6 +222,7 @@
     c.ac = (sheet.ac != null && sheet.ac !== '') ? sheet.ac : 10;
     c.initMod = sheetInitMod(sheet);
     c.attacks = (sheet.attacks || []).map(parseSheetAttack);
+    c.checks = sheetChecks(sheet);
     return c;
   }
 
@@ -536,6 +590,8 @@
     if (c.kind === 'monster' && c.template) o.templateSlug = c.template.slug;
     // NPCs have no library template, so keep their attacks inline.
     if (c.kind === 'npc') o.attacks = c.attacks;
+    // Player/NPC roll-modifier reference (from a sheet) rides the handoff.
+    if (c.checks) o.checks = c.checks;
     return o;
   }
 
@@ -557,6 +613,7 @@
     } else if (o.kind === 'npc') {
       c.attacks = o.attacks || [];
     }
+    if (o.checks) c.checks = o.checks;
     return c;
   }
 

--- a/combat-engine.js
+++ b/combat-engine.js
@@ -152,11 +152,65 @@
     return { spells: spells, casting: casting };
   }
 
+  // 5e skills, keyed to the ability they use. Kept here (not just on the
+  // character page) so a sheet imported into the Game Session can carry its
+  // roll modifiers for quick reference when the AI DM asks for a check.
+  var SHEET_SKILLS = [
+    { key: 'acrobatics', label: 'Acrobatics', ability: 'dex' },
+    { key: 'animalHandling', label: 'Animal Handling', ability: 'wis' },
+    { key: 'arcana', label: 'Arcana', ability: 'int' },
+    { key: 'athletics', label: 'Athletics', ability: 'str' },
+    { key: 'deception', label: 'Deception', ability: 'cha' },
+    { key: 'history', label: 'History', ability: 'int' },
+    { key: 'insight', label: 'Insight', ability: 'wis' },
+    { key: 'intimidation', label: 'Intimidation', ability: 'cha' },
+    { key: 'investigation', label: 'Investigation', ability: 'int' },
+    { key: 'medicine', label: 'Medicine', ability: 'wis' },
+    { key: 'nature', label: 'Nature', ability: 'int' },
+    { key: 'perception', label: 'Perception', ability: 'wis' },
+    { key: 'performance', label: 'Performance', ability: 'cha' },
+    { key: 'persuasion', label: 'Persuasion', ability: 'cha' },
+    { key: 'religion', label: 'Religion', ability: 'int' },
+    { key: 'sleightOfHand', label: 'Sleight of Hand', ability: 'dex' },
+    { key: 'stealth', label: 'Stealth', ability: 'dex' },
+    { key: 'survival', label: 'Survival', ability: 'wis' }
+  ];
+  var ABIL_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
+  // Precompute the d20 modifiers a sheet rolls with (ability checks, saving
+  // throws, skills, initiative, passive Perception) so the Game Session can
+  // show them as a quick-reference panel. Pure data; the engine never rolls
+  // these — it's a lookup the player reads when the DM asks for a check.
+  function sheetChecks(sheet) {
+    var abilities = sheet.abilities || {};
+    var skillProf = sheet.skillProf || {};
+    var saveProf = sheet.saveProf || {};
+    var level = sheet.level || 1;
+    var pb = 2 + Math.floor((level - 1) / 4);
+    function mod(k) { return abilityMod(abilities[k] == null ? 10 : abilities[k]); }
+
+    var abils = ABIL_KEYS.map(function (k) {
+      return { key: k, score: (abilities[k] == null ? 10 : abilities[k]), mod: mod(k) };
+    });
+    var saves = ABIL_KEYS.map(function (k) {
+      var prof = !!saveProf[k];
+      return { key: k, prof: prof, mod: mod(k) + (prof ? pb : 0) };
+    });
+    var skills = SHEET_SKILLS.map(function (s) {
+      var prof = !!skillProf[s.key];
+      return { key: s.key, label: s.label, ability: s.ability, prof: prof, mod: mod(s.ability) + (prof ? pb : 0) };
+    });
+    var passive = 10 + mod('wis') + (skillProf['perception'] ? pb : 0);
+    return { prof: pb, init: sheetInitMod(sheet), passive: passive,
+      abilities: abils, saves: saves, skills: skills };
+  }
+
   function createPlayerFromSheet(sheet) {
     var c = createPlayer(sheet.name || 'Player', sheetInitMod(sheet),
       (sheet.ac != null && sheet.ac !== '' ? sheet.ac : null));
     var sc = sheetSpellcasting(sheet);
     c.spells = sc.spells; c.spellcasting = sc.casting;
+    c.checks = sheetChecks(sheet);
     return c;
   }
 
@@ -170,6 +224,7 @@
     c.attacks = (sheet.attacks || []).map(parseSheetAttack);
     var sc = sheetSpellcasting(sheet);
     c.spells = sc.spells; c.spellcasting = sc.casting;
+    c.checks = sheetChecks(sheet);
     return c;
   }
 
@@ -357,6 +412,7 @@
     if (c.kind === 'npc') o.attacks = c.attacks;
     if (c.spells && c.spells.length) o.spells = c.spells;
     if (c.spellcasting) o.spellcasting = c.spellcasting;
+    if (c.checks) o.checks = c.checks;
     return o;
   }
   function deserializeCombatant(o) {
@@ -382,6 +438,7 @@
     }
     c.spells = o.spells || [];
     c.spellcasting = o.spellcasting || null;
+    c.checks = o.checks || null;
     return c;
   }
 

--- a/play.js
+++ b/play.js
@@ -262,6 +262,42 @@
       '<div class="spell-ref__body">' + body + '</div>' +
     '</details>';
   }
+  // Quick-reference roll modifiers for a sheet-imported player/NPC: ability
+  // checks, saving throws and skills, so when the AI DM asks for (say) an
+  // Investigation check the number is right there on the card. Open by
+  // default for players — this is exactly what they reach for. The engine
+  // never rolls these; the player reads the modifier and rolls their dice.
+  function checksHtml(c) {
+    var ch = c.checks;
+    if (!ch) return '';
+    function chip(label, m, prof) {
+      return '<span class="chk-ref__chip' + (prof ? ' chk-ref__chip--on' : '') + '">' +
+        esc(label) + ' <b>' + signed(m) + '</b></span>';
+    }
+    var abils = ch.abilities.map(function (a) {
+      return chip(a.key.toUpperCase(), a.mod, false);
+    }).join('');
+    var saves = ch.saves.map(function (s) {
+      return chip(s.key.toUpperCase(), s.mod, s.prof);
+    }).join('');
+    var skills = ch.skills.map(function (s) {
+      return chip(s.label, s.mod, s.prof);
+    }).join('');
+    var open = c.kind === 'player' ? ' open' : '';
+    return '<details class="chk-ref"' + open + '>' +
+      '<summary>🎲 Checks &amp; saves' +
+        '<span class="chk-ref__pp">Prof ' + signed(ch.prof) +
+        ' &middot; Passive Perc ' + ch.passive + '</span></summary>' +
+      '<div class="chk-ref__body">' +
+        '<div class="chk-ref__grp"><div class="chk-ref__lbl">Ability checks</div>' +
+          '<div class="chk-ref__chips">' + abils + '</div></div>' +
+        '<div class="chk-ref__grp"><div class="chk-ref__lbl">Saving throws</div>' +
+          '<div class="chk-ref__chips">' + saves + '</div></div>' +
+        '<div class="chk-ref__grp"><div class="chk-ref__lbl">Skills</div>' +
+          '<div class="chk-ref__chips">' + skills + '</div></div>' +
+      '</div>' +
+    '</details>';
+  }
   function conditionsHtml(c) {
     var chips = c.conditions.map(function (cond) {
       var info = DM.conditionInfo(cond);
@@ -317,7 +353,7 @@
           '<span class="item__name">#' + c.id + ' ' + esc(c.name) + '</span>' +
           metaHtml(c) + revealToggleHtml(c) +
         '</div>' +
-        hpBarHtml(c) + statsHtml(c) + spellsHtml(c) + controls +
+        hpBarHtml(c) + statsHtml(c) + checksHtml(c) + spellsHtml(c) + controls +
       '</div>';
   }
 

--- a/style.css
+++ b/style.css
@@ -2117,3 +2117,61 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 }
 .spell-ref__desc { display: block; font-size: 12px; color: #c2c9d6; line-height: 1.4; margin-top: 2px; }
 .player-self__spells { margin-top: 12px; }
+
+/* Quick-reference roll modifiers (ability checks / saves / skills) on a
+   sheet-imported combatant card — mirrors the spell reference styling. */
+.chk-ref {
+    margin-top: 10px;
+    background: #12141a;
+    border: 1px solid #2c3140;
+    border-radius: 8px;
+    padding: 4px 10px;
+}
+.chk-ref > summary {
+    cursor: pointer;
+    font-size: 13px;
+    color: #4aa3df;
+    padding: 4px 2px;
+    list-style: none;
+    user-select: none;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+}
+.chk-ref > summary::-webkit-details-marker { display: none; }
+.chk-ref > summary::before { content: '▸ '; color: #6c7589; }
+.chk-ref[open] > summary::before { content: '▾ '; }
+.chk-ref__pp {
+    color: #8a93a6;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: .3px;
+}
+.chk-ref__body { padding: 6px 2px 4px; }
+.chk-ref__grp { margin-bottom: 8px; }
+.chk-ref__lbl {
+    font-size: 11px;
+    color: #4aa3df;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+.chk-ref__chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.chk-ref__chip {
+    display: inline-block;
+    font-size: 12px;
+    color: #c2c9d6;
+    background: #1d2029;
+    border: 1px solid #2c3140;
+    border-radius: 6px;
+    padding: 2px 7px;
+    line-height: 1.5;
+}
+.chk-ref__chip b { color: #e6e6e6; font-weight: 700; }
+.chk-ref__chip--on {
+    border-color: #2980b9;
+    background: #172634;
+}
+.chk-ref__chip--on b { color: #4aa3df; }


### PR DESCRIPTION
When playing vs the AI DM, a player needs their check modifiers at hand the moment the DM calls for (say) an Investigation check. This surfaces them right on the combatant card.

## What changed

Sheet-imported player/NPC combatants now carry a precomputed set of d20 modifiers — ability checks, saving throws, skills, plus proficiency bonus and passive Perception — and the Game Session renders them as a **🎲 Checks & saves** reference on the card (open by default for players, collapsible like the existing spell reference; proficient rows highlighted).

- **combat-engine.js** — `sheetChecks()` computes the modifiers from a sheet; attached in `createPlayerFromSheet`/`createNpcFromSheet` and carried through serialize/deserialize so they ride the session snapshot.
- **Dice&Monsters.js** — mirrors the same computation in the Encounter Planner (which is self-contained and doesn't load the engine) so a character imported there carries its modifiers through the "Start game session" handoff and saved encounters.
- **play.js** — `checksHtml()` renders the chip grid.
- **style.css** — `chk-ref` styling mirroring the spell reference.

## Safety

The modifiers are the player's own reference data. `visibility.js` rebuilds the player projection from scratch (`playerCombatant`) and never includes `checks`, so nothing new leaks to player clients in shared sessions.

## Testing

Verified in Chromium (Playwright) across both entry paths:
- Direct "Add from sheet" in the Game Session and the Planner → "Start game session" handoff both render the panel.
- Modifier math confirmed (e.g. Investigation +7 for INT 18 at level 8 with proficiency; saving throws apply proficiency; passive Perception + prof bonus in the header).
- Panel is open by default for players and survives reload (serialized into the autosave snapshot).
- No console errors (only the sandbox's blocked external fonts CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjzA3rFPS2TYct7FDn1PZm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjzA3rFPS2TYct7FDn1PZm)_