### PR TITLE
Cut AI DM token usage: strip stale state, cache static prefix, minify

### DIFF
--- a/ai-client.js
+++ b/ai-client.js
@@ -23,6 +23,45 @@
 
   var cfg = { mode: 'direct', endpoint: ANTHROPIC_URL };
 
+  // ---- Usage tracking (measurement, no behaviour change) ----
+  // Running tally for the session so the effect of caching/stripping is
+  // visible in the console. Read live via AIClient.sessionUsage.
+  var sessionUsage = { calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+  // Rough USD estimate at the default model's (claude-opus-4-8) list price:
+  // input $5/M, output $25/M, cache read $0.5/M, cache write (5m) $6.25/M.
+  function estCost(u) {
+    return ((u.input || 0) * 5 + (u.output || 0) * 25 +
+            (u.cacheRead || 0) * 0.5 + (u.cacheWrite || 0) * 6.25) / 1e6;
+  }
+
+  function trackUsage(u) {
+    if (!u) return;
+    var call = {
+      input: u.input_tokens || 0,
+      output: u.output_tokens || 0,
+      cacheRead: u.cache_read_input_tokens || 0,
+      cacheWrite: u.cache_creation_input_tokens || 0
+    };
+    sessionUsage.calls++;
+    sessionUsage.input += call.input;
+    sessionUsage.output += call.output;
+    sessionUsage.cacheRead += call.cacheRead;
+    sessionUsage.cacheWrite += call.cacheWrite;
+    try {
+      console.log('[AI usage] call in=' + call.input + ' out=' + call.output +
+        ' cacheRead=' + call.cacheRead + ' cacheWrite=' + call.cacheWrite +
+        ' ~$' + estCost(call).toFixed(4) +
+        '  | session: ' + sessionUsage.calls + ' calls, ~$' +
+        estCost(sessionUsage).toFixed(3));
+    } catch (e) { /* console unavailable */ }
+  }
+
+  function resetUsage() {
+    sessionUsage.calls = sessionUsage.input = sessionUsage.output =
+      sessionUsage.cacheRead = sessionUsage.cacheWrite = 0;
+  }
+
   function configure(o) {
     if (o.mode) cfg.mode = o.mode;
     if (o.endpoint) cfg.endpoint = o.endpoint;
@@ -67,7 +106,9 @@
           try { var j = JSON.parse(txt); if (j.error && j.error.message) msg = j.error.message; } catch (e) { /* keep raw */ }
           throw new Error('Claude API ' + res.status + ': ' + msg);
         }
-        return JSON.parse(txt);
+        var parsed = JSON.parse(txt);
+        trackUsage(parsed.usage);
+        return parsed;
       });
     });
   }
@@ -92,6 +133,7 @@
     configure: configure,
     getKey: getKey, setKey: setKey, hasKey: hasKey,
     getModel: getModel, setModel: setModel, DEFAULT_MODEL: DEFAULT_MODEL,
-    complete: complete, textOf: textOf, toolCallsOf: toolCallsOf
+    complete: complete, textOf: textOf, toolCallsOf: toolCallsOf,
+    sessionUsage: sessionUsage, resetUsage: resetUsage
   };
 })();

--- a/ai-dm.js
+++ b/ai-dm.js
@@ -33,10 +33,11 @@
     "reaches it. Speak of distance in feet only when it matters (1 cell = 5 ft). " +
     "With no map data, keep positioning vague and narrative.";
 
-  // Compact JSON of the situation the DM can see.
+  // Compact JSON of the situation the DM can see. Minified (no indentation) —
+  // the whitespace of a pretty-printed block is pure token cost.
   function contextBlock(context) {
     return "Current situation (JSON):\n```json\n" +
-      JSON.stringify(context, null, 2) + "\n```";
+      JSON.stringify(context) + "\n```";
   }
 
   // mode: 'scene' (set the scene now) | 'round' (narrate recent events)
@@ -259,9 +260,15 @@
     }
   ];
 
+  // Prefix that opens every state block. Play strips older state blocks from
+  // the history by matching this marker — the model is told the latest block
+  // is authoritative and to ignore earlier state numbers, so re-sending stale
+  // snapshots every turn is pure waste (O(n²) token growth). JSON is minified.
+  var STATE_MARKER = 'CURRENT STATE (authoritative):';
+
   function stateBlock(context) {
-    return "CURRENT STATE (authoritative):\n```json\n" +
-      JSON.stringify(context, null, 2) + "\n```";
+    return STATE_MARKER + "\n```json\n" +
+      JSON.stringify(context) + "\n```";
   }
 
   window.AIDM = {
@@ -269,6 +276,7 @@
     buildNarration: buildNarration,
     CHAT_SYSTEM: CHAT_SYSTEM,
     TOOLS: TOOLS,
-    stateBlock: stateBlock
+    stateBlock: stateBlock,
+    STATE_MARKER: STATE_MARKER
   };
 })();

--- a/play.js
+++ b/play.js
@@ -1046,9 +1046,56 @@
     scheduleSave();
   }
 
+  // Remove the state block from all earlier turns before a new one is added.
+  // Only the newest turn carries the full JSON snapshot; the narration and
+  // tool results (which stay) preserve the story, and the system prompt tells
+  // the model the latest block is authoritative. Turns the old O(n²) growth
+  // (one full state block per turn, resent forever) into O(n).
+  function stripStaleState() {
+    var marker = window.AIDM.STATE_MARKER;
+    for (var i = 0; i < aiMessages.length; i++) {
+      var m = aiMessages[i];
+      if (!m || m.role !== 'user' || !Array.isArray(m.content)) continue;
+      var kept = m.content.filter(function (b) {
+        return !(b && b.type === 'text' && typeof b.text === 'string' &&
+                 b.text.lastIndexOf(marker, 0) === 0);
+      });
+      if (kept.length !== m.content.length && kept.length) m.content = kept;
+    }
+  }
+
+  // Keep exactly one ephemeral cache breakpoint in the message history, on the
+  // very last content block. Within a turn's tool loop the history is
+  // append-only, so each follow-up call re-reads the prior prefix from cache
+  // (~0.1x) instead of paying full price for the whole transcript again.
+  function markCacheBreakpoint() {
+    for (var i = 0; i < aiMessages.length; i++) {
+      var c = aiMessages[i].content;
+      if (!Array.isArray(c)) continue;
+      for (var j = 0; j < c.length; j++) {
+        if (c[j] && c[j].cache_control) delete c[j].cache_control;
+      }
+    }
+    var last = aiMessages[aiMessages.length - 1];
+    if (!last) return;
+    if (typeof last.content === 'string') {
+      last.content = [{ type: 'text', text: last.content }];
+    }
+    if (Array.isArray(last.content) && last.content.length) {
+      last.content[last.content.length - 1].cache_control = { type: 'ephemeral' };
+    }
+  }
+
   function runLoop(iter) {
     var noTools = iter > MAX_TOOL_ITERS;   // hard stop: last call is text-only
-    var req = { system: window.AIDM.CHAT_SYSTEM, messages: aiMessages, max_tokens: 1024 };
+    markCacheBreakpoint();
+    // System + tools are static across the whole session; cache them so only
+    // the first call pays full price for that fixed prefix.
+    var req = {
+      system: [{ type: 'text', text: window.AIDM.CHAT_SYSTEM, cache_control: { type: 'ephemeral' } }],
+      messages: aiMessages,
+      max_tokens: 1024
+    };
     if (!noTools) req.tools = window.AIDM.TOOLS;
 
     window.AIClient.complete(req).then(function (res) {
@@ -1085,7 +1132,11 @@
     });
 
     renderChat('user', displayLabel || userText);
-    aiMessages.push({ role: 'user', content: window.AIDM.stateBlock(ctx) + '\n\n' + userText });
+    stripStaleState();
+    aiMessages.push({ role: 'user', content: [
+      { type: 'text', text: window.AIDM.stateBlock(ctx) },
+      { type: 'text', text: userText }
+    ] });
 
     setAiBusy(true);
     aiStatus('The DM is thinking…');


### PR DESCRIPTION
## Problem

The AI DM chat loop was expensive — a single adventure cost several dollars. Three compounding causes in the send path (`play.js` → `ai-dm.js` → `ai-client.js`):

1. **O(n²) history growth.** Every user turn pushed a full state-block JSON snapshot into `aiMessages` and kept them all forever. By turn 20 each API call resent 20 stale snapshots — which the system prompt already tells the model to ignore.
2. **No prompt caching.** The fixed system prompt + tool schemas (~fixed prefix) were sent uncached on every call, and every tool-loop iteration resent the whole transcript at full price.
3. **Pretty-printed state JSON** — indentation is pure token cost.

## Changes

- **`play.js` — strip stale state:** before each new turn, older state blocks are removed from the history; only the newest turn carries the full snapshot. Narration and tool results stay, so the story is fully preserved and the model (told the latest block is authoritative) loses no context. O(n²) → O(n).
- **`play.js` — prompt caching:** an ephemeral breakpoint on system+tools (static across the session) plus one moving breakpoint on the last message block, so a turn's tool-loop iterations re-read the transcript prefix from cache (~0.1×) instead of resending it at full price.
- **`ai-dm.js`:** minified the state JSON (dropped pretty-print indentation); added `STATE_MARKER` so `play.js` can identify and strip old blocks.
- **`ai-client.js`:** per-call and session token-usage tracking (input/output/cache) with a rough cost estimate, logged to the console and exposed on `AIClient.sessionUsage`, so the effect is measurable.

## Compatibility & safety

- Message-shape change (user `content` is now a block array) is backward compatible — the Anthropic API accepts string or array content, and old saved sessions with string content still load.
- No architecture changes: still vanilla IIFE, no build step, graceful degradation intact.

## Verification

- `node --check` passes on all three files.
- A standalone logic test confirms exactly one (newest) state block survives stripping, the cache breakpoint lands on the last block, and narration / player text / tool results are preserved.
- Live effect is observable in the DevTools console (`[AI usage] …` per call) and via `AIClient.sessionUsage`.

Note: Opus 4.8 caches only prefixes ≥ 4096 tokens; the system+tools breakpoint may no-op early in a session (harmlessly) and the moving message breakpoint engages once the transcript grows — i.e. in the long combats that cost the most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mWmrKCzWwviTthqg2U27V

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWmrKCzWwviTthqg2U27V)_