### PR TITLE
Declutter the Game Session: fold-away panels + windowed AI chat

### DIFF
--- a/play.html
+++ b/play.html
@@ -207,7 +207,10 @@
         <!-- AI Dungeon Master -->
         <section class="ai" id="ai-dm">
             <div class="ai__head">
-                <h2 class="ai__title">AI Dungeon Master</h2>
+                <div class="ai__head-left">
+                    <h2 class="ai__title">AI Dungeon Master</h2>
+                    <span id="ai-key-state" class="ai__keystate" hidden>✓ key saved</span>
+                </div>
                 <button class="btn-ai-settings" type="button" aria-expanded="false">Settings ⚙</button>
             </div>
 
@@ -218,21 +221,28 @@
                 <label class="ai__field">Model
                     <input type="text" id="ai-model" class="ai__input" placeholder="claude-opus-4-8">
                 </label>
-                <label class="ai__field">ElevenLabs API key (voice — optional)
-                    <input type="password" id="voice-key" class="ai__input" placeholder="ElevenLabs key" autocomplete="off">
-                </label>
-                <label class="ai__field">Voice preset
-                    <select id="voice-preset" class="ai__input"></select>
-                </label>
-                <label class="ai__field">Voice ID
-                    <input type="text" id="voice-id" class="ai__input" placeholder="JBFqnCBsd6RMkjVDRZzb">
-                </label>
-                <label class="ai__field">Voice model
-                    <select id="voice-model-preset" class="ai__input"></select>
-                </label>
-                <label class="ai__field">Voice model ID
-                    <input type="text" id="voice-model" class="ai__input" placeholder="eleven_flash_v2_5">
-                </label>
+
+                <details class="ai__voice" id="ai-voice">
+                    <summary class="ai__voice-summary">🔊 Voice (optional — read narration aloud &amp; mic input)</summary>
+                    <div class="ai__voice-body">
+                        <label class="ai__field">ElevenLabs API key
+                            <input type="password" id="voice-key" class="ai__input" placeholder="ElevenLabs key" autocomplete="off">
+                        </label>
+                        <label class="ai__field">Voice preset
+                            <select id="voice-preset" class="ai__input"></select>
+                        </label>
+                        <label class="ai__field">Voice ID
+                            <input type="text" id="voice-id" class="ai__input" placeholder="JBFqnCBsd6RMkjVDRZzb">
+                        </label>
+                        <label class="ai__field">Voice model
+                            <select id="voice-model-preset" class="ai__input"></select>
+                        </label>
+                        <label class="ai__field">Voice model ID
+                            <input type="text" id="voice-model" class="ai__input" placeholder="eleven_flash_v2_5">
+                        </label>
+                    </div>
+                </details>
+
                 <button class="btn-ai-save" type="button">Save</button>
                 <p class="ai__hint">Your keys are stored only in this browser (localStorage). The Anthropic key goes straight to Anthropic; the ElevenLabs key (for reading narration aloud and mic input) goes straight to ElevenLabs. Get them at console.anthropic.com and elevenlabs.io.</p>
             </div>

--- a/play.js
+++ b/play.js
@@ -124,10 +124,10 @@
     // Rebuild the combat log (state.log is oldest-first; insert keeps newest on top).
     el.log.innerHTML = '';
     state.log.forEach(function (e) { appendLogLine(e.text, e.cls); });
-    // Rebuild the AI chat + scene field.
+    // Rebuild the AI chat + scene field (only the last page; older on demand).
     if (el.aiOutput) {
-      el.aiOutput.innerHTML = '';
-      state.chatLog.forEach(function (m) { appendChatBubble(m.role, m.text); });
+      chatRenderStart = Math.max(0, state.chatLog.length - CHAT_PAGE);
+      renderChatWindow(false);
     }
     if (el.aiScene) el.aiScene.value = (state.scene && state.scene.text) || '';
   }
@@ -867,7 +867,7 @@
 
   function aiStatus(text) { if (el.aiStatus) el.aiStatus.textContent = text || ''; }
 
-  function appendChatBubble(role, text) {
+  function appendChatBubble(role, text, opts) {
     if (!text) return;
     var block = document.createElement('div');
     block.className = 'ai__msg ai__msg--' + role;
@@ -893,7 +893,39 @@
       block.textContent = text;
     }
     el.aiOutput.appendChild(block);
-    el.aiOutput.scrollTop = el.aiOutput.scrollHeight;
+    if (!(opts && opts.noScroll)) el.aiOutput.scrollTop = el.aiOutput.scrollHeight;
+    return block;
+  }
+
+  // Only the last CHAT_PAGE bubbles are shown; a "Load earlier" button reveals
+  // older ones in batches so a long session doesn't become an endless scroll.
+  var CHAT_PAGE = 12;
+  var chatRenderStart = 0;
+  function renderChatWindow(keepScroll) {
+    if (!el.aiOutput) return;
+    var log = state.chatLog || [];
+    if (chatRenderStart < 0) chatRenderStart = 0;
+    if (chatRenderStart > log.length) chatRenderStart = log.length;
+    var prevH = el.aiOutput.scrollHeight, prevTop = el.aiOutput.scrollTop;
+    el.aiOutput.innerHTML = '';
+    if (chatRenderStart > 0) {
+      var more = document.createElement('button');
+      more.type = 'button';
+      more.className = 'btn-ai-loadmore';
+      more.textContent = '↑ Load earlier messages (' + chatRenderStart + ')';
+      more.addEventListener('click', function () {
+        chatRenderStart = Math.max(0, chatRenderStart - CHAT_PAGE);
+        renderChatWindow(true);
+      });
+      el.aiOutput.appendChild(more);
+    }
+    for (var i = chatRenderStart; i < log.length; i++) {
+      appendChatBubble(log[i].role, log[i].text, { noScroll: true });
+    }
+    // Keep the reading position when revealing older messages; otherwise jump to newest.
+    el.aiOutput.scrollTop = keepScroll
+      ? prevTop + (el.aiOutput.scrollHeight - prevH)
+      : el.aiOutput.scrollHeight;
   }
   function renderChat(role, text) {
     if (!text) return;
@@ -1147,6 +1179,7 @@
     aiMessages = [];
     state.chatLog = [];
     if (window.Voice) Voice.stop();
+    chatRenderStart = 0;
     if (el.aiOutput) el.aiOutput.innerHTML = '';
     scheduleSave();
     aiStatus('Chat reset.');
@@ -1157,6 +1190,13 @@
     if (!el.aiSettings) return;
     el.aiSettings.hidden = !open;
     if (el.aiSettingsBtn) el.aiSettingsBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+
+  // Show "✓ key saved" beside the title so the user knows a key is stored
+  // without opening the (collapsed) settings panel.
+  function updateKeyState() {
+    if (!el.aiKeyState) return;
+    el.aiKeyState.hidden = !(window.AIClient && window.AIClient.hasKey());
   }
 
   function saveAiSettings() {
@@ -1170,6 +1210,7 @@
       if (el.voiceModel) { Voice.setTtsModel(el.voiceModel.value); el.voiceModel.value = Voice.getTtsModel(); }
       updateVoiceUi();
     }
+    updateKeyState();
     aiStatus('Saved.');
     setTimeout(function () { aiStatus(''); }, 1400);
   }
@@ -1237,6 +1278,7 @@
   function initAi() {
     el.aiSettingsBtn = document.querySelector('.btn-ai-settings');
     el.aiSettings    = document.querySelector('#ai-settings');
+    el.aiKeyState    = document.querySelector('#ai-key-state');
     el.aiKey         = document.querySelector('#ai-key');
     el.aiModel       = document.querySelector('#ai-model');
     el.aiSaveBtn     = document.querySelector('.btn-ai-save');
@@ -1259,6 +1301,7 @@
 
     el.aiKey.value = window.AIClient.getKey();
     el.aiModel.value = window.AIClient.getModel();
+    updateKeyState();
     if (window.Voice) {
       if (el.voiceKey) el.voiceKey.value = Voice.getKey();
       if (el.voiceId) el.voiceId.value = Voice.getVoice();
@@ -1558,6 +1601,7 @@
       state.combatants = []; state.activeId = null; state.log = []; state.chatLog = [];
       renderAll(); renderTurnOrder();
       if (el.log) el.log.innerHTML = '';
+      chatRenderStart = 0;
       if (el.aiOutput) el.aiOutput.innerHTML = '';
       logLine('Left the shared session.', 'spawn');
     }
@@ -1789,6 +1833,41 @@
     }
   }
 
+  // Turn a static section into a fold-away panel: the heading toggles a body
+  // wrapper (built from the heading's following siblings), state persisted.
+  var COLLAPSE_PREFIX = 'diceAndMonsters.collapse.';
+  function makeCollapsible(section, head, key) {
+    if (!section || !head) return;
+    section.classList.add('collapsible');
+    head.classList.add('collapsible__head');
+    var body = document.createElement('div');
+    body.className = 'collapse__body';
+    while (head.nextSibling) body.appendChild(head.nextSibling);
+    section.appendChild(body);
+    var caret = document.createElement('span');
+    caret.className = 'collapsible__caret';
+    caret.textContent = '▾';
+    head.appendChild(caret);
+    var stored = null;
+    try { stored = window.localStorage.getItem(COLLAPSE_PREFIX + key); } catch (e) {}
+    if (stored === '1') section.classList.add('is-collapsed');
+    head.setAttribute('role', 'button');
+    head.setAttribute('tabindex', '0');
+    function sync() {
+      head.setAttribute('aria-expanded', section.classList.contains('is-collapsed') ? 'false' : 'true');
+    }
+    function toggle() {
+      var collapsed = section.classList.toggle('is-collapsed');
+      try { window.localStorage.setItem(COLLAPSE_PREFIX + key, collapsed ? '1' : '0'); } catch (e) {}
+      sync();
+    }
+    sync();
+    head.addEventListener('click', toggle);
+    head.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
+    });
+  }
+
   function init() {
     applyRole();
     el.loadSelect = document.querySelector('#play-load');
@@ -1842,6 +1921,12 @@
     initCloud();
     initBattlemap();
     initRevealPanel();
+
+    // Fold the heavier secondary panels away when they're not in use
+    // (state remembered per-browser). The chat + combatants stay open.
+    makeCollapsible(document.querySelector('#cloud'), document.querySelector('#cloud .cloud__head'), 'cloud');
+    makeCollapsible(document.querySelector('.picker'), document.querySelector('.picker .players__title'), 'add');
+    makeCollapsible(document.querySelector('.logwrap'), document.querySelector('.logwrap__title'), 'log');
 
     // If the planner or an adventure scene handed off a session, load it.
     var handoff = readSessionHandoff();

--- a/style.css
+++ b/style.css
@@ -1223,7 +1223,12 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
     padding: 18px;
 }
 .ai__head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; gap: 10px; }
+.ai__head-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .ai__title { font-size: 16px; color: #9b59b6; }
+.ai__keystate {
+    font-size: 12px; color: #27ae60; background: rgba(39,174,96,.12);
+    border: 1px solid rgba(39,174,96,.35); border-radius: 999px; padding: 2px 9px; white-space: nowrap;
+}
 .btn-ai-settings {
     background: #3b4150; color: #e6e6e6; border: none; border-radius: 6px;
     padding: 6px 12px; font-family: inherit; font-size: 13px; cursor: pointer;
@@ -1250,6 +1255,18 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 .btn-ai-save:hover { background: #2ecc71; }
 .ai__hint { flex-basis: 100%; font-size: 12px; color: #6b7280; margin: 0; }
 
+/* Voice settings tucked into a native <details> so the core AI key isn't buried */
+.ai__voice { flex-basis: 100%; background: #1d2029; border: 1px solid #2c3140; border-radius: 8px; padding: 0; }
+.ai__voice-summary {
+    cursor: pointer; list-style: none; padding: 10px 14px; font-size: 13px; color: #9aa3b2;
+    display: flex; align-items: center; gap: 8px;
+}
+.ai__voice-summary::-webkit-details-marker { display: none; }
+.ai__voice-summary::before { content: '▸'; color: #6b7280; font-size: 11px; transition: transform .15s; }
+.ai__voice[open] > .ai__voice-summary::before { transform: rotate(90deg); }
+.ai__voice-summary:hover { color: #e6e6e6; }
+.ai__voice-body { display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end; padding: 0 14px 14px; }
+
 .ai__row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
 .ai__input--direction { flex: 1; min-width: 180px; width: auto; }
 .btn-ai-scene, .btn-ai-round {
@@ -1265,6 +1282,20 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 
 .ai__output { display: flex; flex-direction: column; gap: 10px; margin-bottom: 12px; max-height: 460px; overflow-y: auto; }
 .ai__output:empty { display: none; }
+.btn-ai-loadmore {
+    align-self: center; background: #2c3140; color: #9aa3b2; border: 1px solid #3b4150;
+    border-radius: 6px; padding: 6px 14px; font-family: inherit; font-size: 12px; cursor: pointer;
+    margin-bottom: 2px; flex-shrink: 0;
+}
+.btn-ai-loadmore:hover { background: #3b4150; color: #e6e6e6; box-shadow: none; }
+
+/* Generic collapsible section (wired up in play.js) — click the heading to fold */
+.collapsible__head { cursor: pointer; user-select: none; display: flex; align-items: center; gap: 8px; }
+.collapsible__head:hover .collapsible__caret { color: #e6e6e6; }
+.collapsible__caret { margin-left: auto; color: #6b7280; font-size: 12px; transition: transform .15s; flex-shrink: 0; }
+.collapsible.is-collapsed .collapsible__caret { transform: rotate(-90deg); }
+.collapsible.is-collapsed .collapse__body { display: none; }
+.collapsible.is-collapsed { padding-bottom: 18px; }
 .ai__msg {
     border-radius: 8px; padding: 10px 14px; white-space: pre-wrap; line-height: 1.5;
     max-width: 92%;


### PR DESCRIPTION
Tidies up the Game Session (`play.html`) so the AI settings and the chat don't take over the screen.

## What changed

**Cleaner AI settings**
- The five ElevenLabs voice fields are tucked into a collapsed `🔊 Voice (optional)` `<details>`, so opening Settings shows just the Anthropic key + model instead of seven fields at once.
- A small green **"✓ key saved"** badge sits next to the "AI Dungeon Master" title, so you can tell a key is stored without opening the (collapsed) settings panel.

**Windowed AI chat with "Load earlier"**
- The chat now renders only the **last 12 bubbles**. A **"↑ Load earlier messages (N)"** button at the top reveals older ones in batches and preserves the reading position (no jump to the bottom), instead of rebuilding the entire transcript on every restore.
- Full history is still persisted in `chatLog` exactly as before — this is display-only.

**Collapsible secondary sections**
- **Cloud saves**, **Add to the fight**, and **Combat log** now fold away via a clickable heading + caret. Open/closed state is remembered per browser in `localStorage` (`diceAndMonsters.collapse.*`). A reusable `makeCollapsible()` helper drives all three (keyboard-accessible: Enter/Space, `role="button"`, `aria-expanded`).

## Notes
- No build step, no new dependencies — plain vanilla JS/CSS, matching the existing IIFE style.
- Verified in headless Chromium: settings/voice collapse, key badge, chat windowing + "Load earlier" (12 → 24 bubbles, newest visible), section collapse persisting across reload, no page errors.
- Nothing goes live until this merges to `master` (which triggers the Pages deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by)_