### PR TITLE
Add floating dice roller to Play vs AI

### DIFF
--- a/play.html
+++ b/play.html
@@ -264,6 +264,36 @@
             <div id="log" class="log"></div>
         </section>
 
+        <!-- Floating dice roller (Play vs AI): tap the die to pick a type,
+             how many, roll and read the result. Uses the engine's dice so
+             rolls stay impartial; each roll is written to the combat log. -->
+        <div class="dice-fab" id="dice-fab">
+            <div class="dice-tray" id="dice-tray" hidden>
+                <div class="dice-tray__head">
+                    <h3 class="dice-tray__title">Roll dice</h3>
+                    <button class="dice-tray__close" type="button" aria-label="Close">✕</button>
+                </div>
+                <div class="dice-tray__dice">
+                    <button type="button" class="dice-chip" data-sides="4">d4</button>
+                    <button type="button" class="dice-chip" data-sides="6">d6</button>
+                    <button type="button" class="dice-chip" data-sides="8">d8</button>
+                    <button type="button" class="dice-chip" data-sides="10">d10</button>
+                    <button type="button" class="dice-chip" data-sides="12">d12</button>
+                    <button type="button" class="dice-chip is-active" data-sides="20">d20</button>
+                    <button type="button" class="dice-chip" data-sides="100">d100</button>
+                </div>
+                <div class="dice-tray__count">
+                    <span class="dice-tray__label">How many</span>
+                    <button class="dice-count__btn" type="button" data-step="-1" aria-label="Fewer dice">−</button>
+                    <input id="dice-count" class="dice-count__input" type="number" min="1" max="20" value="1">
+                    <button class="dice-count__btn" type="button" data-step="1" aria-label="More dice">+</button>
+                </div>
+                <button class="dice-tray__roll" type="button">Roll <span id="dice-roll-label">1d20</span></button>
+                <div class="dice-tray__result" id="dice-result" aria-live="polite"></div>
+            </div>
+            <button class="dice-fab__btn" id="dice-fab-btn" type="button" aria-expanded="false" aria-controls="dice-tray" title="Roll dice">🎲</button>
+        </div>
+
         <!-- Standard 5e conditions as suggestions (free text is also allowed) -->
         <datalist id="conditions-list">
             <option value="Blinded"></option>

--- a/play.js
+++ b/play.js
@@ -1757,6 +1757,90 @@
     el.areaCard.hidden = false;
   }
 
+  /* ---- Floating dice roller (Play vs AI) ----
+     A pinned die in the corner: tap to open a tray, pick a die type and how
+     many, roll and read the result. Rolls go through the engine (DM.rollDie)
+     so they stay impartial, and each roll is written to the combat log. */
+  function initDiceRoller() {
+    var fab = document.querySelector('#dice-fab');
+    if (!fab) return;
+    var toggleBtn = fab.querySelector('#dice-fab-btn');
+    var tray      = fab.querySelector('#dice-tray');
+    var closeBtn  = fab.querySelector('.dice-tray__close');
+    var chips     = fab.querySelectorAll('.dice-chip');
+    var countInput = fab.querySelector('#dice-count');
+    var stepBtns  = fab.querySelectorAll('.dice-count__btn');
+    var rollBtn   = fab.querySelector('.dice-tray__roll');
+    var rollLabel = fab.querySelector('#dice-roll-label');
+    var result    = fab.querySelector('#dice-result');
+    var sides = 20;
+
+    function count() {
+      var n = parseInt(countInput.value, 10);
+      if (!n || n < 1) n = 1;
+      if (n > 20) n = 20;
+      return n;
+    }
+    function updateLabel() { rollLabel.textContent = count() + 'd' + sides; }
+
+    function openTray(open) {
+      tray.hidden = !open;
+      toggleBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    toggleBtn.addEventListener('click', function () { openTray(tray.hidden); });
+    closeBtn.addEventListener('click', function () { openTray(false); });
+
+    Array.prototype.forEach.call(chips, function (chip) {
+      chip.addEventListener('click', function () {
+        Array.prototype.forEach.call(chips, function (c) { c.classList.remove('is-active'); });
+        chip.classList.add('is-active');
+        sides = parseInt(chip.getAttribute('data-sides'), 10) || 20;
+        updateLabel();
+      });
+    });
+
+    Array.prototype.forEach.call(stepBtns, function (b) {
+      b.addEventListener('click', function () {
+        var step = parseInt(b.getAttribute('data-step'), 10) || 0;
+        countInput.value = Math.min(20, Math.max(1, count() + step));
+        updateLabel();
+      });
+    });
+    countInput.addEventListener('input', updateLabel);
+
+    rollBtn.addEventListener('click', function () {
+      var n = count();
+      var rolls = [];
+      var total = 0;
+      for (var i = 0; i < n; i++) {
+        var r = window.DM.rollDie(sides);
+        rolls.push(r);
+        total += r;
+      }
+      renderRoll(n, rolls, total);
+      logLine('🎲 ' + n + 'd' + sides + ': [' + rolls.join(', ') + '] = ' + total, 'roll');
+    });
+
+    function renderRoll(n, rolls, total) {
+      var faces = rolls.map(function (r) {
+        var cls = 'dice-face';
+        if (sides === 20 && r === 20) cls += ' dice-face--crit';
+        if (sides === 20 && r === 1)  cls += ' dice-face--fumble';
+        return '<span class="' + cls + '">' + r + '</span>';
+      }).join('');
+      var totalHtml = n > 1
+        ? '<div class="dice-result__total">Total <strong>' + total + '</strong></div>'
+        : '';
+      result.innerHTML =
+        '<div class="dice-result__expr">' + n + 'd' + sides + '</div>' +
+        '<div class="dice-result__faces">' + faces + '</div>' +
+        totalHtml;
+    }
+
+    updateLabel();
+  }
+
   // Which seat is this: 'ai' (AI DM runs the game) or 'dm' (a human DM).
   // The two share this game session; the role only toggles the AI panel
   // and the page's framing. The player screen is the separate player.html.
@@ -1842,6 +1926,7 @@
     initCloud();
     initBattlemap();
     initRevealPanel();
+    initDiceRoller();
 
     // If the planner or an adventure scene handed off a session, load it.
     var handoff = readSessionHandoff();

--- a/style.css
+++ b/style.css
@@ -1987,6 +1987,108 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 .role-ai #reveal-panel { display: none; }          /* AI is the DM: no manual reveal panel */
 .role-ai .item__reveal { display: none; }          /* …nor per-creature reveal toggles */
 
+/* ============================================================
+   Floating dice roller (Play vs AI) — a pinned die you tap to
+   open a small tray: pick a die, how many, roll and read the
+   result. Hidden on the human DM console.
+   ============================================================ */
+.dice-fab {
+    position: fixed; right: 20px; bottom: 20px; z-index: 60;
+    display: flex; flex-direction: column; align-items: flex-end; gap: 12px;
+}
+.role-dm .dice-fab { display: none; }              /* human DM console: no floating roller */
+.dice-fab__btn {
+    width: 60px; height: 60px; border-radius: 50%;
+    background: #c0392b; color: #fff; border: 2px solid #e1b12c;
+    font-size: 28px; line-height: 1; cursor: pointer;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.5);
+    transition: transform 0.12s ease, background 0.12s ease;
+}
+.dice-fab__btn:hover { background: #d0453a; transform: translateY(-2px); }
+.dice-fab__btn:active { transform: scale(0.94); }
+
+.dice-tray {
+    width: 260px; padding: 14px;
+    background: #1d2029; border: 1px solid #2c3140; border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+}
+.dice-tray__head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 10px;
+}
+.dice-tray__title { font-size: 15px; color: #e1b12c; margin: 0; }
+.dice-tray__close {
+    background: none; border: none; color: #9aa3b2; font-size: 16px;
+    cursor: pointer; line-height: 1; padding: 2px 4px;
+}
+.dice-tray__close:hover { color: #e6e6e6; }
+
+.dice-tray__dice {
+    display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px;
+}
+.dice-chip {
+    flex: 1 0 auto; min-width: 44px; padding: 7px 0;
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140;
+    border-radius: 6px; font-size: 13px; cursor: pointer;
+    transition: border-color 0.12s ease, background 0.12s ease;
+}
+.dice-chip:hover { border-color: #4aa3df; }
+.dice-chip.is-active {
+    background: #2980b9; border-color: #4aa3df; color: #fff; font-weight: 600;
+}
+
+.dice-tray__count {
+    display: flex; align-items: center; gap: 8px; margin-bottom: 12px;
+}
+.dice-tray__label { flex: 1; color: #9aa3b2; font-size: 13px; }
+.dice-count__btn {
+    width: 30px; height: 30px; border-radius: 6px;
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140;
+    font-size: 18px; line-height: 1; cursor: pointer;
+}
+.dice-count__btn:hover { border-color: #4aa3df; }
+.dice-count__input {
+    width: 48px; text-align: center;
+    background: #12141a; color: #e6e6e6; border: 1px solid #2c3140;
+    border-radius: 6px; padding: 6px 4px; font-size: 14px;
+}
+
+.dice-tray__roll {
+    width: 100%; padding: 10px; margin-bottom: 4px;
+    background: #c0392b; color: #fff; border: none; border-radius: 8px;
+    font-size: 15px; font-weight: 600; cursor: pointer;
+    transition: background 0.12s ease;
+}
+.dice-tray__roll:hover { background: #d0453a; }
+
+.dice-tray__result:empty { display: none; }
+.dice-tray__result {
+    margin-top: 12px; padding-top: 12px; border-top: 1px solid #2c3140;
+    text-align: center;
+}
+.dice-result__expr { color: #9aa3b2; font-size: 12px; margin-bottom: 6px; }
+.dice-result__faces {
+    display: flex; flex-wrap: wrap; gap: 6px; justify-content: center;
+}
+.dice-face {
+    min-width: 30px; padding: 5px 8px;
+    background: #12141a; border: 1px solid #2c3140; border-radius: 6px;
+    color: #e6e6e6; font-size: 15px; font-weight: 600;
+}
+.dice-face--crit { border-color: #27ae60; color: #2ecc71; }
+.dice-face--fumble { border-color: #c0392b; color: #ff6b5e; }
+.dice-result__total {
+    margin-top: 10px; color: #e6e6e6; font-size: 14px;
+}
+.dice-result__total strong { color: #e1b12c; font-size: 20px; }
+
+.log__line--roll { color: #e1b12c; }
+
+@media (max-width: 640px) {
+    .dice-fab { right: 12px; bottom: 12px; }
+    .dice-tray { width: min(80vw, 260px); }
+}
+
 /* Player cloud lobby (player.html) */
 .player-cloud {
     max-width: 960px; margin: 0 auto 14px; padding: 14px 16px;


### PR DESCRIPTION
## Summary

Adds a **floating dice button** in the bottom-right corner of the Game Session on the **Play vs AI** seat (`play.html?role=ai`). Tapping the 🎲 opens a small tray where you can:

- Pick a die type — **d4, d6, d8, d10, d12, d20, d100** (d20 default)
- Choose **how many** (1–20, via −/+ stepper or direct input)
- **Roll** and read each individual result plus the total

Natural 20s glow green and natural 1s glow red on d20 rolls, and every roll is written to the combat log (`🎲 3d6: [2, 3, 2] = 7`) so it stays part of the honest record.

## Details

- **Impartial rolls:** goes through the engine's `window.DM.rollDie`, honoring the project rule that the engine (`combat-engine.js`) owns all dice randomness.
- **Role-scoped:** visible only in the AI seat; hidden on the human DM console (`role-dm`) via CSS, matching the existing role-driven layout pattern.
- **No build step:** plain vanilla JS in an IIFE, dark-theme palette reused from `style.css`, mobile-responsive.

## Files changed

- `play.html` — floating dice button + tray markup
- `style.css` — floating button, tray, dice faces, and a `log__line--roll` color; responsive tweaks
- `play.js` — `initDiceRoller()` wired into `init()`

## Testing

Verified in Chromium (Playwright): the button shows on the AI seat and is hidden on the DM console, the tray opens/closes, die-type and count selection update the roll label, rolling produces the correct number of faces + total + a combat-log line. `node --check play.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wzYv5XUM3M53kg9ZvLthr

---
_Generated by [Claude Code](https://claude.ai/code/session_015wzYv5XUM3M53kg9ZvLthr)_