### PR TITLE
Add AI player: an AI teammate that runs a PC on its own turn

### DIFF
--- a/ai-context.js
+++ b/ai-context.js
@@ -45,14 +45,28 @@
     }
     if (DM.hasHp(c)) {
       var isEnemy = (c.kind === 'monster' || c.kind === 'npc');
-      if (isEnemy && opts.hideEnemyHp) {
+      if (opts.self) {
+        // The self block always shows exact HP — the AI needs to know its own.
+        v.hp = c.hp; v.maxHp = c.maxHp;
+      } else if (isEnemy && opts.hideEnemyHp) {
+        v.health = hpBand(c);
+      } else if (c.kind === 'player') {
+        // An AI-controlled PC has an engine HP counter, but its EXACT HP is only
+        // ever exposed through its own self block — in the shared context (DM and
+        // other players) a player's HP is banded, never a raw number.
         v.health = hpBand(c);
       } else {
         v.hp = c.hp; v.maxHp = c.maxHp;
       }
     } else {
-      // No HP counter (a human player in AI-DM mode): never invent one.
+      // No HP counter (a human player): never invent one.
       v.health = 'unknown (player tracks their own)';
+    }
+    if (opts.self) {
+      if (c.spells && c.spells.length) v.spells = c.spells;
+      if (c.spellcasting) v.spellcasting = c.spellcasting;
+      if (c.checks) v.checks = c.checks;
+      if (c.persona) v.persona = c.persona;
     }
     // Battlemap cell, so the DM can reason about position and range.
     if (c.x != null && c.y != null) v.pos = { x: c.x, y: c.y };
@@ -113,7 +127,7 @@
     if (opts.grid) ctx.mapGrid = opts.grid;
     if (opts.selfId != null) {
       var self = DM.findCombatant(state.combatants, opts.selfId);
-      if (self) ctx.self = combatantView(self, { hideEnemyHp: false });
+      if (self) ctx.self = combatantView(self, { self: true });
     }
     return ctx;
   }

--- a/ai-player.js
+++ b/ai-player.js
@@ -1,0 +1,131 @@
+/* ============================================================
+   Dice & Monsters — AI Player
+   ------------------------------------------------------------
+   Pure prompt/tool builders for an AI teammate: Claude sitting
+   in a PLAYER's seat, running one character on its own turn.
+   The same machinery scales from a single AI teammate to a
+   whole AI party — the turn driver just calls it once per
+   AI-controlled PC, each with that PC as `self`.
+
+   Golden rule (mirrors the AI DM): the engine rolls all dice
+   and tracks all HP. The AI player picks an action via a tool;
+   it never states a to-hit number, damage, or HP total itself.
+
+   Secrecy (mirrors a human player): it sees enemy health only
+   as vague bands, never DM notes, hidden creatures, or exact
+   enemy HP — that filtering happens in ai-context.js before the
+   context is ever built (opts.hideEnemyHp), not here.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  var SYSTEM =
+    "You are a PLAYER in a Dungeons & Dragons 5th Edition game — one member of the " +
+    "party, not the Dungeon Master. You control exactly ONE character: the one given " +
+    "as \"self\" in the state block. Play it like a real player would: make its choices, " +
+    "speak in its voice, work with your teammates, and take your turn when it comes up.\n\n" +
+
+    "SELF: the latest user message has a CURRENT STATE block (JSON). Its \"self\" object is " +
+    "YOUR character — your exact HP, AC, attacks, spells and skill modifiers. Everyone else " +
+    "on the field is described from your seat: allies and enemies show only a vague health " +
+    "band (\"healthy\", \"bloodied\", \"near death\"), never exact HP. Use ids/indices from this " +
+    "block; ignore numbers from earlier messages.\n\n" +
+
+    "ACTING — the golden rule:\n" +
+    "• The engine rolls every die and tracks every HP total. To attack, call player_attack; " +
+    "you get the result AFTER the engine rolls. NEVER state a to-hit number, damage amount, " +
+    "or anyone's HP yourself — narrate only from the results the tools give you.\n" +
+    "• On your turn take ONE creature's worth of actions (typically one attack, or a move plus " +
+    "an attack), then call end_turn. Don't act for other characters, roll for the DM, or invent " +
+    "outcomes nobody asked for.\n" +
+    "• BATTLEMAP: if the state has token \"pos\" cells and a \"mapGrid\", use move_token to reposition " +
+    "YOUR character (1 cell = 5 ft; absolute x,y, top-left is 0,0) — close on an enemy, take cover, " +
+    "hold a doorway. With no map, keep movement narrative.\n" +
+    "• Use set_condition on yourself for effects you take on (e.g. Dodge → 'Dodging', going Prone). " +
+    "Don't apply conditions or damage to anyone else — ask the DM or let your attack resolve it.\n" +
+    "• You may cast a spell you have; describe it and, if it's an attack roll, use player_attack with " +
+    "the matching attack entry. The engine does not roll saving throws or damage for save-based spells " +
+    "yet — narrate the intent and let the DM adjudicate.\n\n" +
+
+    "STYLE — a real player at the table, terse and in-character:\n" +
+    "• Speak as your character in first person (\"I\", \"me\"). One or two sharp lines of intent and " +
+    "flavour, not a paragraph. Banter with the party, react to the scene, then act.\n" +
+    "• Lead with what you DO, not a pile of adjectives. Commit to a choice — don't ask the DM which " +
+    "option to pick; that's your call as the player.\n" +
+    "• Speak of distance in feet only when it matters (1 cell = 5 ft).";
+
+  // Fold a character's persona (from its sheet/toggle) into the system prompt so
+  // several AI players sharing this module still feel distinct.
+  function systemFor(persona) {
+    if (!persona) return SYSTEM;
+    return SYSTEM + "\n\nYOUR CHARACTER'S PERSONA (stay in this voice): " + String(persona);
+  }
+
+  var TOOLS = [
+    {
+      name: 'player_attack',
+      description: "Make one attack with YOUR character. The engine rolls the d20 and damage and " +
+        "applies it; you get the outcome back. Use an attack index from your self.attacks, and a " +
+        "targetId from the state.",
+      input_schema: {
+        type: 'object',
+        properties: {
+          attackIndex: { type: 'integer', description: "index into your self.attacks array" },
+          targetId: { type: 'integer', description: 'id of the creature you attack; omit to roll with no target' },
+          say: { type: 'string', description: 'optional short in-character line' }
+        },
+        required: ['attackIndex']
+      }
+    },
+    {
+      name: 'move_token',
+      description: "Move YOUR character's token to a battlemap cell (1 cell = 5 ft). Only works when " +
+        "the state has a battlemap (token \"pos\" / \"mapGrid\"); give absolute cell coordinates x,y " +
+        "(top-left is 0,0).",
+      input_schema: {
+        type: 'object',
+        properties: {
+          x: { type: 'integer', description: 'target column (0-based)' },
+          y: { type: 'integer', description: 'target row (0-based)' },
+          say: { type: 'string', description: 'optional short flavour of the movement' }
+        },
+        required: ['x', 'y']
+      }
+    },
+    {
+      name: 'set_condition',
+      description: 'Add or remove a condition on YOUR character (e.g. Dodging, Prone).',
+      input_schema: {
+        type: 'object',
+        properties: {
+          condition: { type: 'string' },
+          mode: { type: 'string', enum: ['add', 'remove'] }
+        },
+        required: ['condition', 'mode']
+      }
+    },
+    {
+      name: 'end_turn',
+      description: "End your character's turn. Call this once you have finished acting so play passes on.",
+      input_schema: { type: 'object', properties: {
+        say: { type: 'string', description: 'optional closing in-character line' }
+      } }
+    }
+  ];
+
+  // Same marker convention as the AI DM so play.js can strip stale state blocks
+  // from the shared transcript regardless of which agent produced the turn.
+  var STATE_MARKER = 'CURRENT STATE (authoritative):';
+
+  function stateBlock(context) {
+    return STATE_MARKER + "\n```json\n" + JSON.stringify(context) + "\n```";
+  }
+
+  window.AIPlayer = {
+    SYSTEM: SYSTEM,
+    systemFor: systemFor,
+    TOOLS: TOOLS,
+    stateBlock: stateBlock,
+    STATE_MARKER: STATE_MARKER
+  };
+})();

--- a/combat-engine.js
+++ b/combat-engine.js
@@ -78,6 +78,9 @@
       x: null,             // battlemap column (null = not placed yet)
       y: null,             // battlemap row
       hidden: false,       // DM-only: not yet revealed to players (role-based visibility)
+      aiControlled: false, // handed to the AI teammate/party (drives its own turns)
+      persona: '',         // optional roleplay persona for an AI-controlled PC
+      sheetHp: null,       // a player sheet's max HP, held aside until AI takes over
       spells: [],          // [{ name, level, notes }] — reference only, engine never casts
       spellcasting: null   // { ability, dc, atk } when the sheet has a casting ability
     };
@@ -211,6 +214,34 @@
     var sc = sheetSpellcasting(sheet);
     c.spells = sc.spells; c.spellcasting = sc.casting;
     c.checks = sheetChecks(sheet);
+    // Stash the sheet's max HP WITHOUT giving the player an HP counter — a human
+    // player tracks their own HP (hasHp stays false). It's only promoted to a
+    // real maxHp/hp counter if the player is later handed to the AI, so the AI
+    // teammate can take damage and reason about its own health.
+    c.attacks = (sheet.attacks || []).map(parseSheetAttack);
+    var maxHp = (sheet.hp && sheet.hp.max) ? sheet.hp.max : 0;
+    c.sheetHp = maxHp > 0 ? maxHp : null;
+    return c;
+  }
+
+  // Hand a combatant to (or back from) the AI. For a player this also plumbs an
+  // engine HP counter: an AI teammate needs real HP so damage lands and it can
+  // gauge its own health, whereas a human player carries none. Reverting a
+  // player clears the counter back to "tracks their own". Monsters/NPCs already
+  // have HP, so only the flag/persona change for them.
+  function setAiControlled(c, on, opts) {
+    opts = opts || {};
+    if (on) {
+      c.aiControlled = true;
+      if (opts.persona != null) c.persona = String(opts.persona);
+      if (c.kind === 'player' && c.maxHp == null) {
+        var hp = intOr(opts.hp, 0) || c.sheetHp || 10;
+        c.maxHp = hp; c.hp = hp;
+      }
+    } else {
+      c.aiControlled = false;
+      if (c.kind === 'player') { c.maxHp = null; c.hp = null; c.dead = false; }
+    }
     return c;
   }
 
@@ -407,9 +438,12 @@
       x: (c.x == null ? null : c.x), y: (c.y == null ? null : c.y)
     };
     if (c.hidden) o.hidden = true;   // only carried when set (keeps old saves compatible)
+    if (c.aiControlled) o.aiControlled = true;   // ditto — AI teammate flag
+    if (c.persona) o.persona = c.persona;
+    if (c.sheetHp != null) o.sheetHp = c.sheetHp;
     if (c.kind === 'monster' && c.template) o.templateSlug = c.template.slug;
     else if (c.kind === 'monster') o.attacks = c.attacks;   // custom monster (no library template)
-    if (c.kind === 'npc') o.attacks = c.attacks;
+    if (c.kind === 'npc' || c.kind === 'player') o.attacks = c.attacks;
     if (c.spells && c.spells.length) o.spells = c.spells;
     if (c.spellcasting) o.spellcasting = c.spellcasting;
     if (c.checks) o.checks = c.checks;
@@ -419,6 +453,9 @@
     var c = baseCombatant(o.kind, o.name);
     if (o.id != null) { c.id = o.id; bumpIdPast(o.id); }  // stable ids across a synced snapshot
     c.hidden = !!o.hidden;
+    c.aiControlled = !!o.aiControlled;
+    c.persona = o.persona || '';
+    c.sheetHp = (o.sheetHp == null ? null : o.sheetHp);
     c.hp = (o.hp == null ? null : o.hp);
     c.maxHp = (o.maxHp == null ? null : o.maxHp);
     c.ac = (o.ac == null ? null : o.ac);
@@ -433,7 +470,7 @@
       var t = templateBySlug(o.templateSlug);
       if (t) { c.template = t; c.attacks = t.attacks || []; }
       else { c.attacks = o.attacks || []; }   // custom monster: restore its ad-hoc attacks
-    } else if (o.kind === 'npc') {
+    } else if (o.kind === 'npc' || o.kind === 'player') {
       c.attacks = o.attacks || [];
     }
     c.spells = o.spells || [];
@@ -460,6 +497,7 @@
     findCombatant: findCombatant, combatantLabel: combatantLabel,
     hasHp: hasHp, canBeTargeted: canBeTargeted,
     isHidden: isHidden, setHidden: setHidden,
+    setAiControlled: setAiControlled,
     // conditions
     CONDITION_INFO: CONDITION_INFO, conditionInfo: conditionInfo,
     addCondition: addCondition, removeCondition: removeCondition,

--- a/plan.md
+++ b/plan.md
@@ -38,17 +38,58 @@ cloud saves and shared live sessions so several people watch the same game.
   ElevenLabs; hidden entirely until a key is set, so the app is unchanged
   without one.
 
-## Next up (rough priority)
+## AI Player — design (Phase 3, in progress)
 
-1. **AI Player (Phase 3)** — the original goal: Claude controls **one** character
-   at the table. Chosen shape (from earlier decisions): tied to a real character
-   **sheet** (1a) and it **acts on its own** (2b), with **enemy HP hidden** from
-   it. **Prerequisite / do this first:** AI-controlled characters must carry HP
-   in the engine (today `createPlayerFromSheet` gives players no HP, so damage
-   isn't applied and the AI can't reason about its own health). Plumb HP for
-   AI-controlled PCs (treat mechanically like an NPC but on the players' side).
-   Reuse `ai-context.js` (`opts.hideEnemyHp`, `opts.selfId`) and add
-   `ai-player.js` (persona + `take_action` tool) mirroring `ai-dm.js`.
+The original goal: Claude sits in a *player's* seat and runs a character. The key
+realisation from the design pass: **"an extra AI teammate" and "a full AI party"
+are the same capability, not two features.** Both are just "an AI that controls
+one or more PCs, driven on each PC's turn." So we build **one** engine and expose
+it as a per-combatant flag; N=1 is a solo AI teammate, N=all is a self-playing
+party. It is also **orthogonal to who DMs** — it must work under the AI DM
+(`?role=ai`), a human DM Console (`?role=dm`), and solo. So it lives in the Game
+Session page as a per-creature toggle, **not** bolted onto the AI-DM chat panel.
+
+### Decisions (locked)
+
+- **Tied to a real character sheet** (HP/attacks/spells/checks come from the sheet).
+- **Per-character loop** — the turn driver calls the model once per AI PC with that
+  PC as `self` + its own persona. Scales evenly 1 → whole party, keeps distinct
+  voices, and limits metagaming (each PC mainly "sees itself"). Costlier than one
+  shared brain, but the existing prompt-cache breakpoint in `runLoop` softens it.
+- **Enemy HP hidden** from the AI player (`AIContext.build(state,{ hideEnemyHp:true,
+  selfId })`), and it never sees `dmNotes` / hidden creatures — same secrecy rules
+  as a human player.
+- **Player HP stays hidden from the DM context.** An AI PC gets *engine-tracked* HP
+  (so damage lands and it can reason about its health), but that exact HP is exposed
+  **only** through its own `self` block — in the shared context every player's HP is
+  banded (`healthy`/`bloodied`/…), never exact. Human players still carry no HP.
+- **Auto on its turn, behind one toggle** — "Auto-run AI turns". When initiative
+  reaches an AI PC it acts itself; combined with the AI DM this yields a self-playing
+  table. The driver always **stops on a human PC's turn** and has a hard iteration
+  cap so it can't run away.
+
+### Build order
+
+1. **Engine HP plumbing** ✅ — `createPlayerFromSheet` stashes the sheet's max HP as
+   `c.sheetHp` (kept separate so human players still have no HP counter).
+   `DM.setAiControlled(c, on, opts)` toggles `c.aiControlled` + `c.persona` and, for a
+   player, gives/removes an engine HP counter (`maxHp`/`hp`). `aiControlled`,
+   `persona`, `sheetHp` are serialized (only when set, so old saves still load).
+2. **`ai-player.js` → `window.AIPlayer`** ✅ — mirrors `ai-dm.js`: a player persona
+   system prompt + a lean tool set (`player_attack`, `move_token`, `set_condition`,
+   `end_turn`) and a `stateBlock`/`STATE_MARKER`. The engine still rolls everything
+   (`player_attack` routes through the same `resolveAttack`/`performAttack` path as
+   `monster_action`).
+3. **Per-card UI toggle** — a "🤖 Let AI play this" control on each player card that
+   calls `setAiControlled`, plus a persona field. Serialized in the snapshot.
+4. **Turn driver** — generalise `runLoop` to take `{ system, tools, executor }` so it
+   can drive either the DM or a specific AI PC. An "Auto-run AI turns" toggle: when the
+   active combatant is an AI PC, run its `AIPlayer` turn; when it's a monster/NPC and
+   the AI DM is on, run the DM; stop on a human PC. Hard iteration cap.
+5. **Presets** — thin wrappers over the flag: "Add an AI teammate" (flag one) and
+   "Fill the party with AI" (flag all players).
+6. **Visibility check** — confirm an AI PC's context never carries `dmNotes`, hidden
+   creatures, or exact enemy HP (reuse `hideEnemyHp` + self-only exact HP).
 2. **NPC-HP fix** — `DM.createNpcFromSheet` defaults maxHp to 1 when the sheet has
    no HP, so imported NPCs die instantly. Default to something sane or prompt.
 3. **Trim Encounter Planner to pure prep** — now that Play is self-sufficient,

--- a/play.html
+++ b/play.html
@@ -246,6 +246,7 @@
             <div class="ai__row ai__row--quick">
                 <button class="btn-ai-scene" type="button">Describe scene</button>
                 <button class="btn-ai-round" type="button">Run monsters’ turn</button>
+                <button class="btn-ai-auto" type="button" aria-pressed="false" title="When it's an AI-played character's turn, let it act on its own">🤖 Auto AI turns: off</button>
                 <button class="btn-ai-reset" type="button" title="Start a fresh conversation">Reset chat</button>
                 <button class="btn-ai-speak" type="button" hidden aria-pressed="false" title="Read the DM's narration aloud">🔊 Voice off</button>
                 <span id="ai-status" class="ai__status"></span>
@@ -292,6 +293,7 @@
         <script src="ai-context.js"></script>
         <script src="ai-client.js"></script>
         <script src="ai-dm.js"></script>
+        <script src="ai-player.js"></script>
         <script src="voice.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
         <script src="supabase-config.js"></script>

--- a/play.js
+++ b/play.js
@@ -127,7 +127,7 @@
     // Rebuild the AI chat + scene field.
     if (el.aiOutput) {
       el.aiOutput.innerHTML = '';
-      state.chatLog.forEach(function (m) { appendChatBubble(m.role, m.text); });
+      state.chatLog.forEach(function (m) { appendChatBubble(m.role, m.text, m.who); });
     }
     if (el.aiScene) el.aiScene.value = (state.scene && state.scene.text) || '';
   }
@@ -320,13 +320,22 @@
     '</div>' + effectsHtml;
   }
   function playerControlsHtml(c) {
+    var ai = !!c.aiControlled;
+    var aiRow = '<div class="ai-ctrl">' +
+      '<button class="btn-ai-toggle ' + (ai ? 'is-on' : '') + '" data-action="toggle-ai" title="' +
+        (ai ? 'The AI is playing this character — click to hand it back to a human' :
+              'Let the AI play this character on its own turns') + '">' +
+        (ai ? '🤖 AI plays this' : '🤖 Let AI play') + '</button>' +
+      (ai ? '<input class="ai-ctrl__persona" data-role="persona" placeholder="persona (optional)" value="' +
+        esc(c.persona || '') + '">' : '') +
+    '</div>';
     return '<div class="manual">' +
       '<label class="ac-edit">AC <input type="number" min="0" ' +
         'class="manual__input manual__input--ac" data-role="ac" ' +
         'value="' + (c.ac != null ? c.ac : '') + '" placeholder="–"></label>' +
       '<button class="btn-set-ac" data-action="set-ac">Set AC</button>' +
       '<button class="btn-remove" data-action="remove">Remove</button>' +
-    '</div>';
+    '</div>' + aiRow;
   }
   // Per-creature visibility toggle. Players never receive a hidden
   // creature (it's stripped in visibility.js before the projection is
@@ -529,6 +538,43 @@
     renderTurnOrder();
   }
 
+  // "Next turn" from the UI: advance, then let an AI teammate take over if the
+  // new active combatant is AI-controlled and auto-run is on.
+  function nextTurnUi() {
+    nextTurn();
+    maybeRunAiTurn();
+  }
+
+  /* ---- Auto-run driver: chain AI teammates through their turns ---- */
+  var autoRunAi = false;
+  var autoTurnGuard = 0;   // stops a runaway loop (e.g. an all-AI table with no end)
+
+  // If auto-run is on and it's an AI teammate's turn, run it, then advance and
+  // repeat. Stops on a human PC or a monster/NPC (the DM runs those). Never
+  // fires while another AI call is in flight (aiBusy) or for viewers.
+  function maybeRunAiTurn() {
+    if (viewerMode || aiBusy || !autoRunAi) return;
+    if (state.activeId == null) return;
+    var c = findCombatant(state.activeId);
+    if (!c || c.dead) return;
+    if (!(c.kind === 'player' && c.aiControlled)) return;
+    if (autoTurnGuard++ > 60) { setAutoRunAi(false); aiStatus('Auto AI turns stopped (turn cap reached).'); return; }
+    runAiPlayerTurn(c, function () {
+      nextTurn();
+      maybeRunAiTurn();
+    });
+  }
+
+  function setAutoRunAi(on) {
+    autoRunAi = !!on;
+    autoTurnGuard = 0;
+    if (el.aiAutoBtn) {
+      el.aiAutoBtn.setAttribute('aria-pressed', autoRunAi ? 'true' : 'false');
+      el.aiAutoBtn.textContent = autoRunAi ? '🤖 Auto AI turns: on' : '🤖 Auto AI turns: off';
+    }
+    if (autoRunAi) maybeRunAiTurn();
+  }
+
   function removeCombatant(id) {
     var c = findCombatant(id);
     state.combatants = state.combatants.filter(function (x) { return x.id !== id; });
@@ -616,9 +662,32 @@
       logLine(label(c) + (c.hidden ? ' is now hidden from players.' : ' is revealed to players.'), 'spawn');
       rerenderCard(c);
       persistState();   // republish the player projection immediately
+    } else if (action === 'toggle-ai') {
+      var on = !c.aiControlled;
+      DM.setAiControlled(c, on);
+      logLine(label(c) + (on ? ' is now played by the AI' +
+        (c.maxHp != null ? ' (' + c.hp + '/' + c.maxHp + ' HP).' : '.') :
+        ' is back under human control.'), 'spawn');
+      renderAll();
+      renderTurnOrder();
+      scheduleSave();
+      maybeRunAiTurn();
     } else if (action === 'remove') {
       removeCombatant(id);
     }
+  }
+
+  // Live-edit an AI teammate's persona from its card (no re-render, so the
+  // field keeps focus while typing).
+  function onListInput(ev) {
+    if (viewerMode) return;
+    var inp = ev.target;
+    if (!inp.matches || !inp.matches('input[data-role="persona"]')) return;
+    var cardNode = inp.closest('.item');
+    var c = cardNode && findCombatant(parseInt(cardNode.getAttribute('data-id'), 10));
+    if (!c) return;
+    c.persona = inp.value;
+    scheduleSave();
   }
 
   function commitTrackInit(c) {
@@ -867,10 +936,21 @@
 
   function aiStatus(text) { if (el.aiStatus) el.aiStatus.textContent = text || ''; }
 
-  function appendChatBubble(role, text) {
+  function appendChatBubble(role, text, who) {
     if (!text) return;
     var block = document.createElement('div');
     block.className = 'ai__msg ai__msg--' + role;
+    // An AI teammate's line is tagged with the character's name.
+    if (role === 'player' && who) {
+      var ws = document.createElement('span');
+      ws.className = 'ai__msg-who';
+      ws.textContent = who + ':';
+      block.appendChild(ws);
+      block.appendChild(document.createTextNode(text));
+      el.aiOutput.appendChild(block);
+      el.aiOutput.scrollTop = el.aiOutput.scrollHeight;
+      return;
+    }
     // DM lines get a ▶ replay button so ElevenLabs can read them aloud again.
     if (role === 'dm' && window.Voice && Voice.hasKey()) {
       var span = document.createElement('span');
@@ -895,10 +975,10 @@
     el.aiOutput.appendChild(block);
     el.aiOutput.scrollTop = el.aiOutput.scrollHeight;
   }
-  function renderChat(role, text) {
+  function renderChat(role, text, who) {
     if (!text) return;
-    appendChatBubble(role, text);
-    state.chatLog.push({ role: role, text: text });
+    appendChatBubble(role, text, who);
+    state.chatLog.push({ role: role, text: text, who: who || undefined });
     // Read new DM narration aloud when voice is on (never the player's own lines).
     if (role === 'dm' && window.Voice && Voice.isAuto() && Voice.hasKey() && !viewerMode) {
       Voice.enqueue(text).catch(function (e) { aiStatus((e && e.message) || 'Voice error.'); });
@@ -1044,6 +1124,7 @@
     aiStatus('');
     setAiBusy(false);
     scheduleSave();
+    maybeRunAiTurn();   // the DM may have advanced onto an AI teammate's turn
   }
 
   // Remove the state block from all earlier turns before a new one is added.
@@ -1068,15 +1149,15 @@
   // very last content block. Within a turn's tool loop the history is
   // append-only, so each follow-up call re-reads the prior prefix from cache
   // (~0.1x) instead of paying full price for the whole transcript again.
-  function markCacheBreakpoint() {
-    for (var i = 0; i < aiMessages.length; i++) {
-      var c = aiMessages[i].content;
+  function markCacheBreakpoint(messages) {
+    for (var i = 0; i < messages.length; i++) {
+      var c = messages[i].content;
       if (!Array.isArray(c)) continue;
       for (var j = 0; j < c.length; j++) {
         if (c[j] && c[j].cache_control) delete c[j].cache_control;
       }
     }
-    var last = aiMessages[aiMessages.length - 1];
+    var last = messages[messages.length - 1];
     if (!last) return;
     if (typeof last.content === 'string') {
       last.content = [{ type: 'text', text: last.content }];
@@ -1086,34 +1167,155 @@
     }
   }
 
-  function runLoop(iter) {
+  // Agent-agnostic tool loop. Drives either the AI DM or a specific AI player
+  // over cfg.messages, with cfg.system / cfg.tools / cfg.executor. Each AI
+  // player's turn uses its OWN short-lived cfg.messages (not the DM transcript)
+  // so it never sees the DM's hidden reasoning — the visibility rule holds even
+  // inside the model's context. cfg: { system, tools, messages, executor,
+  // speaker, speakerName, onDone }.
+  function runAgentLoop(cfg, iter) {
+    iter = iter || 0;
     var noTools = iter > MAX_TOOL_ITERS;   // hard stop: last call is text-only
-    markCacheBreakpoint();
-    // System + tools are static across the whole session; cache them so only
-    // the first call pays full price for that fixed prefix.
+    markCacheBreakpoint(cfg.messages);
+    // System + tools are static; cache them so only the first call pays full
+    // price for that fixed prefix.
     var req = {
-      system: [{ type: 'text', text: window.AIDM.CHAT_SYSTEM, cache_control: { type: 'ephemeral' } }],
-      messages: aiMessages,
+      system: [{ type: 'text', text: cfg.system, cache_control: { type: 'ephemeral' } }],
+      messages: cfg.messages,
       max_tokens: 1024
     };
-    if (!noTools) req.tools = window.AIDM.TOOLS;
+    if (!noTools) req.tools = cfg.tools;
 
     window.AIClient.complete(req).then(function (res) {
-      aiMessages.push({ role: 'assistant', content: res.content });
-      renderChat('dm', window.AIClient.textOf(res));
+      cfg.messages.push({ role: 'assistant', content: res.content });
+      renderChat(cfg.speaker || 'dm', window.AIClient.textOf(res), cfg.speakerName);
 
       var toolCalls = window.AIClient.toolCallsOf(res);
       if (!noTools && res.stop_reason === 'tool_use' && toolCalls.length) {
-        var results = toolCalls.map(executeToolCall);
-        aiMessages.push({ role: 'user', content: results });
-        runLoop(iter + 1);
+        var results = toolCalls.map(cfg.executor);
+        cfg.messages.push({ role: 'user', content: results });
+        // A tool may end the turn (an AI player's end_turn) — stop the loop
+        // instead of prompting the model for yet another action.
+        if (cfg.stopAfter && cfg.stopAfter(toolCalls)) cfg.onDone();
+        else runAgentLoop(cfg, iter + 1);
       } else {
-        finishChat();
+        cfg.onDone();
       }
     }).catch(function (err) {
       aiStatus((err && err.message) || 'Something went wrong.');
       setAiBusy(false);
+      if (cfg.onError) cfg.onError(err);
     });
+  }
+
+  // The AI DM shares one persistent transcript across the whole session.
+  function runLoop(iter) {
+    runAgentLoop({
+      system: window.AIDM.CHAT_SYSTEM,
+      tools: window.AIDM.TOOLS,
+      messages: aiMessages,
+      executor: executeToolCall,
+      speaker: 'dm',
+      onDone: finishChat
+    }, iter);
+  }
+
+  /* ---- AI player: an AI teammate takes its own turn ---- */
+
+  // Tool executor bound to one AI-controlled PC. The character is implicit
+  // (`self`), so these tools never take a combatantId for the actor — an AI
+  // player can only act as itself, never puppet another creature.
+  function executePlayerTool(self) {
+    return function (block) {
+      var input = block.input || {};
+      var id = block.id;
+      try {
+        if (block.name === 'end_turn') {
+          if (input.say) renderChat('player', input.say, self.name);
+          return toolResult(id, 'Turn ended.');
+        }
+        if (block.name === 'player_attack') {
+          var attack = self.attacks && self.attacks[input.attackIndex];
+          if (!attack) return toolResult(id, self.name + ' has no attack at index ' + input.attackIndex + '.', true);
+          var target = (input.targetId != null) ? findCombatant(input.targetId) : null;
+          if (input.targetId != null && !target) return toolResult(id, 'No target with id ' + input.targetId + '.', true);
+          if (input.say) renderChat('player', input.say, self.name);
+          var summary = performAttack(self, attack, target);
+          renderAll();
+          return toolResult(id, summary);
+        }
+        if (block.name === 'set_condition') {
+          if (input.mode === 'remove') {
+            DM.removeCondition(self, input.condition);
+            logLine(label(self) + ' is no longer ' + input.condition + '.', 'spawn');
+          } else {
+            DM.addCondition(self, input.condition);
+            logLine(label(self) + ' is now ' + input.condition + '.', 'spawn');
+          }
+          rerenderCard(self); renderTurnOrder();
+          return toolResult(id, label(self) + ' conditions: ' + (self.conditions.join(', ') || 'none') + '.');
+        }
+        if (block.name === 'move_token') {
+          if (!window.Battlemap) return toolResult(id, 'There is no battlemap in this session.', true);
+          var sz = window.Battlemap.size();
+          var nx = parseInt(input.x, 10), ny = parseInt(input.y, 10);
+          if (isNaN(nx) || isNaN(ny) || nx < 0 || ny < 0 || nx >= sz.cols || ny >= sz.rows) {
+            return toolResult(id, 'Cell ' + input.x + ',' + input.y + ' is off the ' + sz.cols + '×' + sz.rows + ' map.', true);
+          }
+          var from = (self.x != null && self.y != null) ? (self.x + ',' + self.y) : 'off-map';
+          self.x = nx; self.y = ny;
+          if (input.say) renderChat('player', input.say, self.name);
+          renderAll();
+          logLine(label(self) + ' moves to ' + nx + ',' + ny + '.', 'spawn');
+          scheduleSave();
+          return toolResult(id, label(self) + ' moved from ' + from + ' to ' + nx + ',' + ny + '.');
+        }
+        return toolResult(id, 'Unknown tool: ' + block.name, true);
+      } catch (e) {
+        return toolResult(id, 'Tool error: ' + ((e && e.message) || e), true);
+      }
+    };
+  }
+
+  // Run one AI-controlled PC's turn. Uses a fresh, short-lived message list
+  // (seeded with the self-scoped context) — never the DM transcript — so the
+  // teammate only ever sees what a player may see. onDone fires when the turn
+  // ends (or errors), so the auto-driver can advance to the next combatant.
+  function runAiPlayerTurn(self, onDone) {
+    onDone = onDone || function () {};
+    if (!window.AIClient || !window.AIPlayer || !window.AIContext) { aiStatus('AI scripts not loaded.'); onDone(); return; }
+    if (!window.AIClient.hasKey()) { aiStatus('Add your Anthropic API key in Settings first.'); onDone(); return; }
+
+    var ctx = window.AIContext.build(state, {
+      selfId: self.id,
+      hideEnemyHp: true,
+      scene: state.scene,
+      areas: window.Battlemap ? window.Battlemap.getAreas() : null,
+      grid: window.Battlemap ? window.Battlemap.grid() : null
+    });
+    var messages = [{ role: 'user', content: [
+      { type: 'text', text: window.AIPlayer.stateBlock(ctx) },
+      { type: 'text', text: "It's your turn, " + self.name + ". Take your action, then end your turn." }
+    ] }];
+
+    setAiBusy(true);
+    aiStatus(self.name + ' is deciding…');
+    runAgentLoop({
+      system: window.AIPlayer.systemFor(self.persona),
+      tools: window.AIPlayer.TOOLS,
+      messages: messages,
+      executor: executePlayerTool(self),
+      speaker: 'player',
+      speakerName: self.name,
+      stopAfter: function (calls) {
+        return calls.some(function (b) { return b && b.name === 'end_turn'; });
+      },
+      onDone: function () {
+        renderAll(); renderTurnOrder(); aiStatus(''); setAiBusy(false); scheduleSave();
+        onDone();
+      },
+      onError: onDone
+    }, 0);
   }
 
   function sendChat(userText, displayLabel) {
@@ -1243,6 +1445,7 @@
     el.aiScene       = document.querySelector('#ai-scene');
     el.aiSceneBtn    = document.querySelector('.btn-ai-scene');
     el.aiRoundBtn    = document.querySelector('.btn-ai-round');
+    el.aiAutoBtn     = document.querySelector('.btn-ai-auto');
     el.aiResetBtn    = document.querySelector('.btn-ai-reset');
     el.aiInput       = document.querySelector('#ai-input');
     el.aiSendBtn     = document.querySelector('.btn-ai-send');
@@ -1321,6 +1524,7 @@
     el.aiRoundBtn.addEventListener('click', function () {
       sendChat("It's the monsters' and NPCs' turn — run their actions against the party now, one creature at a time, then stop.", "▶ Run monsters’ turn");
     });
+    if (el.aiAutoBtn) el.aiAutoBtn.addEventListener('click', function () { setAutoRunAi(!autoRunAi); });
     el.aiResetBtn.addEventListener('click', resetChat);
     el.aiSendBtn.addEventListener('click', function () {
       var v = el.aiInput.value; el.aiInput.value = ''; sendChat(v);
@@ -1832,8 +2036,9 @@
     el.loadBtn.addEventListener('click', loadSelectedEncounter);
     el.clearBtn.addEventListener('click', clearTable);
     el.initBtn.addEventListener('click', rollInitiative);
-    el.nextBtn.addEventListener('click', nextTurn);
+    el.nextBtn.addEventListener('click', nextTurnUi);
     el.list.addEventListener('click', onListClick);
+    el.list.addEventListener('input', onListInput);
     el.list.addEventListener('keydown', onListKeydown);
     el.turnOrder.addEventListener('click', onTrackClick);
     el.turnOrder.addEventListener('keydown', onTrackKeydown);

--- a/style.css
+++ b/style.css
@@ -1285,6 +1285,11 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
     background: #1f2b38; border-right: 3px solid #4aa3df; color: #e6e6e6;
     align-self: flex-end;
 }
+.ai__msg--player {
+    background: #12141a; border-left: 3px solid #27ae60; color: #d7dbe2;
+    align-self: flex-start;
+}
+.ai__msg--player .ai__msg-who { color: #27ae60; font-weight: 600; margin-right: 6px; }
 
 .ai__row--quick { gap: 8px; }
 .btn-ai-reset { background: #3b4150; color: #e6e6e6; }
@@ -1301,6 +1306,25 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 }
 .btn-ai-mic:hover { background: #2c3140; }
 .btn-ai-mic[aria-pressed="true"] { background: #c0392b; color: #fff; }
+.btn-ai-auto {
+    background: #3b4150; color: #e6e6e6; border: none; border-radius: 6px;
+    padding: 8px 12px; font-family: inherit; font-size: 13px; cursor: pointer;
+}
+.btn-ai-auto:hover { background: #2c3140; }
+.btn-ai-auto[aria-pressed="true"] { background: #27ae60; color: #fff; }
+
+/* AI-teammate toggle on a player card */
+.ai-ctrl { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-top: 8px; }
+.btn-ai-toggle {
+    background: #12141a; color: #cfd4dd; border: 1px solid #3b4150; border-radius: 6px;
+    padding: 6px 12px; font-family: inherit; font-size: 13px; cursor: pointer;
+}
+.btn-ai-toggle:hover { background: #2c3140; }
+.btn-ai-toggle.is-on { background: #27ae60; color: #fff; border-color: #27ae60; }
+.ai-ctrl__persona {
+    flex: 1; min-width: 160px; background: #12141a; color: #e6e6e6;
+    border: 1px solid #2c3140; border-radius: 6px; padding: 6px 10px; font-family: inherit; font-size: 13px;
+}
 
 .ai__composer { margin-bottom: 0; }
 .ai__input--chat { flex: 1; min-width: 200px; width: auto; }


### PR DESCRIPTION
## What this adds

The **AI player** capability: Claude sitting in a *player's* seat, running one character on its own turn. Built as **one engine exposed as a per-combatant flag** — N=1 is a solo AI teammate, N=all is a self-playing party. It's orthogonal to who DMs, so it works under the AI DM, a human DM Console, or solo.

`plan.md` carries the full design + locked decisions.

## Changes

**Engine (`combat-engine.js`)**
- `createPlayerFromSheet` stashes the sheet's max HP as `sheetHp` **without** giving a human player an HP counter, and carries the sheet's attacks.
- `setAiControlled(c, on, opts)` toggles `aiControlled` + `persona` and, for a player, plumbs a real engine HP counter (from `sheetHp` or a fallback) so the AI teammate takes damage and can gauge its own health; reverting clears it. New fields are serialized only when set, so old saves still load.

**Context (`ai-context.js`)**
- A player's *exact* HP is exposed **only** through its own `self` block; in the shared context (DM and other players) player HP is banded, never raw. Enemy HP stays hidden (`hideEnemyHp`).
- The `self` block also carries spells, checks and persona.

**`ai-player.js` (new, `window.AIPlayer`)**
- Player persona system prompt + a lean tool set (`player_attack`, `move_token`, `set_condition`, `end_turn`) mirroring `ai-dm.js`. The engine still rolls everything.

**`play.js`**
- Generalised the tool loop into `runAgentLoop({ system, tools, messages, executor, … })`. The AI DM keeps its persistent transcript; each AI-player turn uses a **fresh, self-scoped** message list so it never sees the DM's hidden reasoning — the visibility rule holds even inside the model's context.
- `executePlayerTool` routes `player_attack` through the same `resolveAttack` path as `monster_action`; a `stopAfter` hook ends the loop on `end_turn`.
- Per-player-card "🤖 Let AI play" toggle + persona field, and an "🤖 Auto AI turns" master toggle that chains AI teammates through their turns (stops on humans/monsters, hard turn cap). The master toggle keeps AI turns from firing (and spending BYOK API calls) until explicitly enabled.

## Testing

- `node --check` on all touched files.
- Engine: HP plumbing + serialization round-trip (human player has no HP counter; AI player gets one; revert clears it).
- Context: `self` shows exact HP, everyone else (incl. the AI player) banded, enemy HP hidden.
- Browser smoke (headless Chromium): all modules load, no JS errors (only the expected blocked external CDNs in-sandbox).
- End-to-end with a stubbed API: `player_attack` + `end_turn` → engine applies damage and the turn ends.

Note: the live AI-DM/AI-player network path can't be exercised in the sandbox (external hosts blocked); the loop refactor is behaviour-preserving for the DM path by construction.

## Not in this PR (follow-ups)

- Auto-driver currently runs AI *players* only; letting it also auto-run the AI *DM* for a fully hands-off table.
- "Add an AI teammate" / "Fill the party with AI" preset buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117LQMFW1ejKSRGtbjuvUqU)_