### PR TITLE
AI settings as native <details> + Opus/Sonnet model picker

### DIFF
--- a/play.html
+++ b/play.html
@@ -211,41 +211,50 @@
                     <h2 class="ai__title">AI Dungeon Master</h2>
                     <span id="ai-key-state" class="ai__keystate" hidden>✓ key saved</span>
                 </div>
-                <button class="btn-ai-settings" type="button" aria-expanded="false">Settings ⚙</button>
             </div>
 
-            <div class="ai__settings" id="ai-settings" hidden>
-                <label class="ai__field">Anthropic API key
-                    <input type="password" id="ai-key" class="ai__input" placeholder="sk-ant-…" autocomplete="off">
-                </label>
-                <label class="ai__field">Model
-                    <input type="text" id="ai-model" class="ai__input" placeholder="claude-opus-4-8">
-                </label>
+            <details class="ai__settings" id="ai-settings">
+                <summary class="ai__settings-summary">Settings ⚙</summary>
+                <div class="ai__settings-body">
+                    <label class="ai__field">Anthropic API key
+                        <input type="password" id="ai-key" class="ai__input" placeholder="sk-ant-…" autocomplete="off">
+                    </label>
+                    <label class="ai__field">Model
+                        <select id="ai-model" class="ai__input">
+                            <option value="claude-opus-4-8">Opus 4.8 — smartest DM</option>
+                            <option value="claude-sonnet-5">Sonnet 5 — faster &amp; cheaper</option>
+                            <option value="__custom__">Custom…</option>
+                        </select>
+                    </label>
+                    <label class="ai__field" id="ai-model-custom-field" hidden>Custom model id
+                        <input type="text" id="ai-model-custom" class="ai__input" placeholder="claude-…">
+                    </label>
 
-                <details class="ai__voice" id="ai-voice">
-                    <summary class="ai__voice-summary">🔊 Voice (optional — read narration aloud &amp; mic input)</summary>
-                    <div class="ai__voice-body">
-                        <label class="ai__field">ElevenLabs API key
-                            <input type="password" id="voice-key" class="ai__input" placeholder="ElevenLabs key" autocomplete="off">
-                        </label>
-                        <label class="ai__field">Voice preset
-                            <select id="voice-preset" class="ai__input"></select>
-                        </label>
-                        <label class="ai__field">Voice ID
-                            <input type="text" id="voice-id" class="ai__input" placeholder="JBFqnCBsd6RMkjVDRZzb">
-                        </label>
-                        <label class="ai__field">Voice model
-                            <select id="voice-model-preset" class="ai__input"></select>
-                        </label>
-                        <label class="ai__field">Voice model ID
-                            <input type="text" id="voice-model" class="ai__input" placeholder="eleven_flash_v2_5">
-                        </label>
-                    </div>
-                </details>
+                    <details class="ai__voice" id="ai-voice">
+                        <summary class="ai__voice-summary">🔊 Voice (optional — read narration aloud &amp; mic input)</summary>
+                        <div class="ai__voice-body">
+                            <label class="ai__field">ElevenLabs API key
+                                <input type="password" id="voice-key" class="ai__input" placeholder="ElevenLabs key" autocomplete="off">
+                            </label>
+                            <label class="ai__field">Voice preset
+                                <select id="voice-preset" class="ai__input"></select>
+                            </label>
+                            <label class="ai__field">Voice ID
+                                <input type="text" id="voice-id" class="ai__input" placeholder="JBFqnCBsd6RMkjVDRZzb">
+                            </label>
+                            <label class="ai__field">Voice model
+                                <select id="voice-model-preset" class="ai__input"></select>
+                            </label>
+                            <label class="ai__field">Voice model ID
+                                <input type="text" id="voice-model" class="ai__input" placeholder="eleven_flash_v2_5">
+                            </label>
+                        </div>
+                    </details>
 
-                <button class="btn-ai-save" type="button">Save</button>
-                <p class="ai__hint">Your keys are stored only in this browser (localStorage). The Anthropic key goes straight to Anthropic; the ElevenLabs key (for reading narration aloud and mic input) goes straight to ElevenLabs. Get them at console.anthropic.com and elevenlabs.io.</p>
-            </div>
+                    <button class="btn-ai-save" type="button">Save</button>
+                    <p class="ai__hint">Your keys are stored only in this browser (localStorage). The Anthropic key goes straight to Anthropic; the ElevenLabs key (for reading narration aloud and mic input) goes straight to ElevenLabs. Get them at console.anthropic.com and elevenlabs.io.</p>
+                </div>
+            </details>
 
             <label class="ai__field ai__field--wide">Scene (optional — grounds the DM; “DM notes:” stays private)
                 <textarea id="ai-scene" class="ai__textarea" rows="3" placeholder="Paste or write the current scene's read-aloud text (and DM notes: …)"></textarea>

--- a/play.js
+++ b/play.js
@@ -1187,9 +1187,27 @@
   }
 
   function showAiSettings(open) {
-    if (!el.aiSettings) return;
-    el.aiSettings.hidden = !open;
-    if (el.aiSettingsBtn) el.aiSettingsBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    // #ai-settings is a native <details>; toggling .open is the whole job.
+    if (el.aiSettings) el.aiSettings.open = !!open;
+  }
+
+  // The model <select> offers Opus/Sonnet plus a "Custom…" escape hatch that
+  // reveals a free-text field for any other model id.
+  var MODEL_PRESETS = ['claude-opus-4-8', 'claude-sonnet-5'];
+  function syncModelSelect() {
+    if (!el.aiModel) return;
+    var m = window.AIClient.getModel();
+    var known = MODEL_PRESETS.indexOf(m) !== -1;
+    el.aiModel.value = known ? m : '__custom__';
+    if (el.aiModelCustom) el.aiModelCustom.value = known ? '' : m;
+    if (el.aiModelCustomField) el.aiModelCustomField.hidden = known;
+  }
+  function chosenModel() {
+    if (!el.aiModel) return '';
+    if (el.aiModel.value === '__custom__') {
+      return ((el.aiModelCustom && el.aiModelCustom.value) || '').trim();
+    }
+    return el.aiModel.value;
   }
 
   // Show "✓ key saved" beside the title so the user knows a key is stored
@@ -1201,9 +1219,8 @@
 
   function saveAiSettings() {
     window.AIClient.setKey((el.aiKey.value || '').trim());
-    var model = (el.aiModel.value || '').trim();
-    window.AIClient.setModel(model || window.AIClient.DEFAULT_MODEL);
-    el.aiModel.value = window.AIClient.getModel();
+    window.AIClient.setModel(chosenModel() || window.AIClient.DEFAULT_MODEL);
+    syncModelSelect();
     if (window.Voice) {
       if (el.voiceKey) Voice.setKey(el.voiceKey.value);
       if (el.voiceId) { Voice.setVoice(el.voiceId.value); el.voiceId.value = Voice.getVoice(); }
@@ -1276,11 +1293,12 @@
   }
 
   function initAi() {
-    el.aiSettingsBtn = document.querySelector('.btn-ai-settings');
     el.aiSettings    = document.querySelector('#ai-settings');
     el.aiKeyState    = document.querySelector('#ai-key-state');
     el.aiKey         = document.querySelector('#ai-key');
     el.aiModel       = document.querySelector('#ai-model');
+    el.aiModelCustom = document.querySelector('#ai-model-custom');
+    el.aiModelCustomField = document.querySelector('#ai-model-custom-field');
     el.aiSaveBtn     = document.querySelector('.btn-ai-save');
     el.aiScene       = document.querySelector('#ai-scene');
     el.aiSceneBtn    = document.querySelector('.btn-ai-scene');
@@ -1300,8 +1318,13 @@
     if (!el.aiOutput || !window.AIClient) return;
 
     el.aiKey.value = window.AIClient.getKey();
-    el.aiModel.value = window.AIClient.getModel();
+    syncModelSelect();
     updateKeyState();
+    el.aiModel.addEventListener('change', function () {
+      var custom = el.aiModel.value === '__custom__';
+      if (el.aiModelCustomField) el.aiModelCustomField.hidden = !custom;
+      if (custom && el.aiModelCustom) el.aiModelCustom.focus();
+    });
     if (window.Voice) {
       if (el.voiceKey) el.voiceKey.value = Voice.getKey();
       if (el.voiceId) el.voiceId.value = Voice.getVoice();
@@ -1356,7 +1379,6 @@
       state.scene = v ? { text: v, title: (state.scene && state.scene.title) || '' } : null;
       scheduleSave();
     });
-    el.aiSettingsBtn.addEventListener('click', function () { showAiSettings(el.aiSettings.hidden); });
     el.aiSaveBtn.addEventListener('click', saveAiSettings);
     el.aiSceneBtn.addEventListener('click', function () {
       sendChat('Set the scene for the players, based on the scene text and the current situation.', '▶ Describe scene');

--- a/style.css
+++ b/style.css
@@ -1229,16 +1229,22 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
     font-size: 12px; color: #27ae60; background: rgba(39,174,96,.12);
     border: 1px solid rgba(39,174,96,.35); border-radius: 999px; padding: 2px 9px; white-space: nowrap;
 }
-.btn-ai-settings {
-    background: #3b4150; color: #e6e6e6; border: none; border-radius: 6px;
-    padding: 6px 12px; font-family: inherit; font-size: 13px; cursor: pointer;
-}
-.btn-ai-settings:hover { background: #2c3140; }
-
+/* Settings is a native <details> so the toggle can't silently break */
 .ai__settings {
-    background: #12141a; border: 1px solid #2c3140; border-radius: 8px;
-    padding: 14px; margin-bottom: 12px;
+    background: #12141a; border: 1px solid #2c3140; border-radius: 8px; margin-bottom: 12px;
+}
+.ai__settings-summary {
+    cursor: pointer; list-style: none; user-select: none;
+    padding: 10px 14px; font-size: 13px; color: #e6e6e6;
+    display: flex; align-items: center; gap: 8px;
+}
+.ai__settings-summary::-webkit-details-marker { display: none; }
+.ai__settings-summary::before { content: '▸'; color: #6b7280; font-size: 11px; transition: transform .15s; }
+.ai__settings[open] > .ai__settings-summary::before { transform: rotate(90deg); }
+.ai__settings-summary:hover { background: #1d2029; border-radius: 8px 8px 0 0; }
+.ai__settings-body {
     display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end;
+    padding: 0 14px 14px;
 }
 .ai__field { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #9aa3b2; flex: 1; min-width: 180px; }
 .ai__field--wide { width: 100%; flex-basis: 100%; margin-bottom: 12px; }


### PR DESCRIPTION
Follow-up to #6. Makes the AI settings reliably hideable and lets you pick the model.

## What changed

**Settings is now a native `<details>`**
- The old "Settings ⚙" button toggled the panel via JavaScript; if that handler didn't run (stale cache / JS hiccup) the button appeared to do nothing. The panel is now a native `<details>`/`<summary>` — the browser handles the fold, so it can't silently break. API key + model live inside it and are collapsed by default.
- Dropped `.btn-ai-settings` and its click wiring; `showAiSettings()` now just sets `details.open`.

**Model picker (Opus / Sonnet / Custom)**
- The free-text model field is now a `<select>`: **Opus 4.8** (default), **Sonnet 5**, or **Custom…** which reveals a text input for any other model id.
- A saved model that isn't one of the presets restores as "Custom" with the field pre-filled; preset models restore selected.

## Notes
- No build step, no new dependencies — plain vanilla JS/CSS, IIFE style unchanged.
- Verified in headless Chromium: settings fold open/closed, model choice saves and survives reload, non-preset ids round-trip through Custom, "✓ key saved" badge, voice block still nested & collapsed, no page errors.
- Nothing goes live until this merges to `master` (which triggers the Pages deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by)_