### PR TITLE
Add Haiku 4.5 to the AI DM model picker

### DIFF
--- a/play.html
+++ b/play.html
@@ -223,6 +223,7 @@
                         <select id="ai-model" class="ai__input">
                             <option value="claude-opus-4-8">Opus 4.8 — smartest DM</option>
                             <option value="claude-sonnet-5">Sonnet 5 — faster &amp; cheaper</option>
+                            <option value="claude-haiku-4-5">Haiku 4.5 — cheapest, good enough</option>
                             <option value="__custom__">Custom…</option>
                         </select>
                     </label>

--- a/play.js
+++ b/play.js
@@ -1396,7 +1396,7 @@
 
   // The model <select> offers Opus/Sonnet plus a "Custom…" escape hatch that
   // reveals a free-text field for any other model id.
-  var MODEL_PRESETS = ['claude-opus-4-8', 'claude-sonnet-5'];
+  var MODEL_PRESETS = ['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5'];
   function syncModelSelect() {
     if (!el.aiModel) return;
     var m = window.AIClient.getModel();


### PR DESCRIPTION
Follow-up to #9. Adds a third, cheapest option to the AI DM model dropdown.

## What changed
- New `<option>` **"Haiku 4.5 — cheapest, good enough"** (`claude-haiku-4-5`) in the model `<select>`, alongside Opus 4.8 and Sonnet 5.
- Registered `claude-haiku-4-5` in the `MODEL_PRESETS` list in `play.js` so a saved Haiku model restores **selected** rather than falling through to "Custom…".

## Why
Haiku 4.5 ($1/$5 per 1M tokens — roughly one-fifth of Opus) works with the existing Claude tool loop with no code-path changes, so it's the cheapest option that runs out of the box for engine-driven combat plus light narration.

## Notes
- No build step, no new dependencies — plain vanilla JS/HTML, matching the existing style.
- Verified in headless Chromium: the Haiku option appears, selects, saves to `localStorage`, and restores as a preset (not "Custom") across reload; no page errors.
- Nothing goes live until this merges to `master` (which triggers the Pages deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by)_