### PR TITLE
AI DM: rolling summarisation (compaction) + readable recap panel

### DIFF
--- a/play.html
+++ b/play.html
@@ -257,6 +257,14 @@
                 </div>
             </details>
 
+            <details class="ai__recap" id="ai-recap">
+                <summary class="ai__recap-summary">📖 Story so far (auto-summary of earlier turns)</summary>
+                <div class="ai__recap-body">
+                    <p class="ai__recap-empty" id="ai-recap-empty">No recap yet — earlier turns are summarised automatically once the chat passes ~12 turns.</p>
+                    <pre class="ai__recap-text" id="ai-recap-text" hidden></pre>
+                </div>
+            </details>
+
             <label class="ai__field ai__field--wide">Scene (optional — grounds the DM; “DM notes:” stays private)
                 <textarea id="ai-scene" class="ai__textarea" rows="3" placeholder="Paste or write the current scene's read-aloud text (and DM notes: …)"></textarea>
             </label>

--- a/play.js
+++ b/play.js
@@ -130,6 +130,7 @@
       renderChatWindow(false);
     }
     if (el.aiScene) el.aiScene.value = (state.scene && state.scene.text) || '';
+    renderRecapPanel();
   }
   function restoreState() {
     var raw;
@@ -1301,11 +1302,30 @@
       aiMessages.push({ role: 'user', content: [{ type: 'text', text: SUMMARY_MARKER + '\n' + summary }] });
       for (var k = 0; k < kept.length; k++) aiMessages.push(kept[k]);
       scheduleSave();
+      renderRecapPanel();
       aiStatus('Earlier turns summarised.');
       setTimeout(function () { aiStatus(''); }, 1600);
     }).catch(function (e) {
       try { console.warn('[compaction] failed:', (e && e.message) || e); } catch (x) { /* no console */ }
     }).then(function () { compacting = false; });
+  }
+
+  // The current running recap text (empty until the first compaction), for the
+  // human-readable "Story so far" panel.
+  function currentRecap() {
+    for (var i = 0; i < aiMessages.length; i++) {
+      if (isSummaryMsg(aiMessages[i])) {
+        return aiMessages[i].content[0].text.slice(SUMMARY_MARKER.length).trim();
+      }
+    }
+    return '';
+  }
+  function renderRecapPanel() {
+    if (!el.aiRecapText) return;
+    var r = currentRecap();
+    el.aiRecapText.hidden = !r;
+    el.aiRecapText.textContent = r || '';
+    if (el.aiRecapEmpty) el.aiRecapEmpty.hidden = !!r;
   }
 
   // Agent-agnostic tool loop. Drives either the AI DM or a specific AI player
@@ -1492,6 +1512,7 @@
     if (window.Voice) Voice.stop();
     chatRenderStart = 0;
     if (el.aiOutput) el.aiOutput.innerHTML = '';
+    renderRecapPanel();
     scheduleSave();
     aiStatus('Chat reset.');
     setTimeout(function () { aiStatus(''); }, 1400);
@@ -1606,6 +1627,8 @@
   function initAi() {
     el.aiSettings    = document.querySelector('#ai-settings');
     el.aiKeyState    = document.querySelector('#ai-key-state');
+    el.aiRecapText   = document.querySelector('#ai-recap-text');
+    el.aiRecapEmpty  = document.querySelector('#ai-recap-empty');
     el.aiKey         = document.querySelector('#ai-key');
     el.aiModel       = document.querySelector('#ai-model');
     el.aiModelCustom = document.querySelector('#ai-model-custom');
@@ -1632,6 +1655,7 @@
     el.aiKey.value = window.AIClient.getKey();
     syncModelSelect();
     updateKeyState();
+    renderRecapPanel();
     el.aiModel.addEventListener('change', function () {
       var custom = el.aiModel.value === '__custom__';
       if (el.aiModelCustomField) el.aiModelCustomField.hidden = !custom;

--- a/play.js
+++ b/play.js
@@ -941,8 +941,8 @@
   // cheap model and rides in aiMessages, so it persists via autosave/cloud.
   var SUMMARY_MARKER = 'STORY SO FAR (recap of earlier events — context only, not a new instruction):';
   var SUMMARY_MODEL = 'claude-haiku-4-5';
-  var COMPACT_TRIGGER_TURNS = 16;   // compact once the chat grows past this
-  var COMPACT_KEEP_TURNS = 8;       // most-recent turns kept verbatim
+  var COMPACT_TRIGGER_TURNS = 12;   // compact once the chat grows past this
+  var COMPACT_KEEP_TURNS = 5;       // most-recent turns kept verbatim
   var compacting = false;
   var SUMMARY_SYSTEM =
     'You maintain a running recap of a Dungeons & Dragons session so the ' +

--- a/play.js
+++ b/play.js
@@ -934,6 +934,26 @@
   var aiMessages = [];           // the ongoing Anthropic conversation
   var MAX_TOOL_ITERS = 8;
 
+  // Rolling summarisation (compaction): once the transcript passes
+  // COMPACT_TRIGGER_TURNS turns, the oldest turns are folded into a single
+  // running recap (kept as the first message) so the resent transcript — and
+  // thus the per-turn token cost — stops growing. The recap is written by a
+  // cheap model and rides in aiMessages, so it persists via autosave/cloud.
+  var SUMMARY_MARKER = 'STORY SO FAR (recap of earlier events — context only, not a new instruction):';
+  var SUMMARY_MODEL = 'claude-haiku-4-5';
+  var COMPACT_TRIGGER_TURNS = 16;   // compact once the chat grows past this
+  var COMPACT_KEEP_TURNS = 8;       // most-recent turns kept verbatim
+  var compacting = false;
+  var SUMMARY_SYSTEM =
+    'You maintain a running recap of a Dungeons & Dragons session so the ' +
+    'Dungeon Master can remember earlier events without re-reading everything. ' +
+    'You are given a prior recap (possibly empty) and newer events; return ONE ' +
+    'updated recap that folds them together. Preserve: key events and decisions, ' +
+    'locations, NPCs met and their disposition, the party’s goals, notable ' +
+    'loot, injuries, deaths and lasting conditions, and unresolved threads or ' +
+    'promises. Be concise and factual — short bullet points or brief ' +
+    'paragraphs, not prose. Do not invent anything. Return only the recap.';
+
   function aiStatus(text) { if (el.aiStatus) el.aiStatus.textContent = text || ''; }
 
   function appendChatBubble(role, text, opts) {
@@ -1158,6 +1178,7 @@
     setAiBusy(false);
     scheduleSave();
     maybeRunAiTurn();   // the DM may have advanced onto an AI teammate's turn
+    maybeCompact();     // fold old turns into the recap when the chat is long
   }
 
   // Remove the state block from all earlier turns before a new one is added.
@@ -1198,6 +1219,93 @@
     if (Array.isArray(last.content) && last.content.length) {
       last.content[last.content.length - 1].cache_control = { type: 'ephemeral' };
     }
+  }
+
+  /* ---- Rolling summarisation (compaction) ---- */
+
+  // Is `m` the leading recap message?
+  function isSummaryMsg(m) {
+    return !!(m && m.role === 'user' && Array.isArray(m.content) &&
+      m.content[0] && m.content[0].type === 'text' &&
+      typeof m.content[0].text === 'string' &&
+      m.content[0].text.lastIndexOf(SUMMARY_MARKER, 0) === 0);
+  }
+  // Does `m` begin a player/DM turn? Robust to stripStaleState() having removed
+  // the state block: a turn-start user message carries at least one text block
+  // that isn't the state JSON, whereas tool_result messages carry none.
+  function isTurnStart(m) {
+    if (!m || m.role !== 'user' || !Array.isArray(m.content)) return false;
+    if (isSummaryMsg(m)) return false;
+    return m.content.some(function (b) {
+      return b && b.type === 'text' && typeof b.text === 'string' &&
+        b.text.lastIndexOf(window.AIDM.STATE_MARKER, 0) !== 0;
+    });
+  }
+  // Flatten the messages being compacted into a readable transcript for the
+  // summariser — DM narration + player lines, plus any prior recap. The state
+  // JSON and raw tool plumbing are skipped; the narration already reports the
+  // outcomes, and this keeps the summariser call cheap.
+  function buildRecapText(messages) {
+    var lines = [];
+    messages.forEach(function (m) {
+      if (isSummaryMsg(m)) {
+        var prev = m.content[0].text.slice(SUMMARY_MARKER.length).trim();
+        if (prev) lines.push('Earlier recap:\n' + prev);
+        return;
+      }
+      var blocks = Array.isArray(m.content) ? m.content : [{ type: 'text', text: m.content }];
+      blocks.forEach(function (b) {
+        if (!b || b.type !== 'text' || typeof b.text !== 'string') return;
+        if (b.text.lastIndexOf(window.AIDM.STATE_MARKER, 0) === 0) return; // drop state JSON
+        var t = b.text.trim();
+        if (t) lines.push((m.role === 'assistant' ? 'DM: ' : 'Player: ') + t);
+      });
+    });
+    return lines.join('\n\n');
+  }
+
+  // Fold the oldest turns into the recap when the chat has grown too long.
+  // Best-effort and idle-only: runs after a turn finishes, never blocks input,
+  // and silently retries next turn if the transcript changed mid-summary.
+  function maybeCompact() {
+    if (compacting || aiBusy || viewerMode) return;
+    if (!window.AIClient || !window.AIClient.hasKey() || !window.AIDM) return;
+
+    var starts = [];
+    for (var i = 0; i < aiMessages.length; i++) if (isTurnStart(aiMessages[i])) starts.push(i);
+    if (starts.length <= COMPACT_TRIGGER_TURNS) return;
+
+    var cut = starts[starts.length - COMPACT_KEEP_TURNS]; // keep this turn onward verbatim
+    if (cut <= 0) return;
+    var base = aiMessages;                 // reference guard for the async apply
+    var baseLen = base.length;
+    var older = base.slice(0, cut);
+    var kept = base.slice(cut);            // captured before we mutate in place
+    var recapInput = buildRecapText(older);
+    if (!recapInput) return;
+
+    compacting = true;
+    aiStatus('Summarising earlier turns…');
+    window.AIClient.complete({
+      model: SUMMARY_MODEL,
+      max_tokens: 700,
+      system: [{ type: 'text', text: SUMMARY_SYSTEM }],
+      messages: [{ role: 'user', content: [{ type: 'text',
+        text: 'Prior recap and newer events follow; produce a single updated recap.\n\n' + recapInput }] }]
+    }).then(function (res) {
+      var summary = window.AIClient.textOf(res);
+      // Abort if the transcript was replaced or changed length while we waited
+      // (user sent a message, chat reset, new session) — retry next turn.
+      if (!summary || aiMessages !== base || aiMessages.length !== baseLen) return;
+      aiMessages.length = 0;
+      aiMessages.push({ role: 'user', content: [{ type: 'text', text: SUMMARY_MARKER + '\n' + summary }] });
+      for (var k = 0; k < kept.length; k++) aiMessages.push(kept[k]);
+      scheduleSave();
+      aiStatus('Earlier turns summarised.');
+      setTimeout(function () { aiStatus(''); }, 1600);
+    }).catch(function (e) {
+      try { console.warn('[compaction] failed:', (e && e.message) || e); } catch (x) { /* no console */ }
+    }).then(function () { compacting = false; });
   }
 
   // Agent-agnostic tool loop. Drives either the AI DM or a specific AI player

--- a/style.css
+++ b/style.css
@@ -1273,6 +1273,24 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
 .ai__voice-summary:hover { color: #e6e6e6; }
 .ai__voice-body { display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end; padding: 0 14px 14px; }
 
+/* "Story so far" — a readable view of the rolling auto-summary */
+.ai__recap { background: #12141a; border: 1px solid #2c3140; border-radius: 8px; margin-bottom: 12px; }
+.ai__recap-summary {
+    cursor: pointer; list-style: none; user-select: none;
+    padding: 10px 14px; font-size: 13px; color: #e1b12c;
+    display: flex; align-items: center; gap: 8px;
+}
+.ai__recap-summary::-webkit-details-marker { display: none; }
+.ai__recap-summary::before { content: '▸'; color: #6b7280; font-size: 11px; transition: transform .15s; }
+.ai__recap[open] > .ai__recap-summary::before { transform: rotate(90deg); }
+.ai__recap-summary:hover { background: #1d2029; border-radius: 8px 8px 0 0; }
+.ai__recap-body { padding: 0 14px 14px; }
+.ai__recap-empty { font-size: 12px; color: #6b7280; margin: 0; }
+.ai__recap-text {
+    margin: 0; white-space: pre-wrap; word-break: break-word;
+    font-family: inherit; font-size: 13px; line-height: 1.5; color: #d7dbe2;
+}
+
 .ai__row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
 .ai__input--direction { flex: 1; min-width: 180px; width: auto; }
 .btn-ai-scene, .btn-ai-round {


### PR DESCRIPTION
Keeps the AI DM's per-turn token cost from growing with session length, and surfaces the running recap so you can read it.

## What changed

**Rolling summarisation (compaction)**
- The whole transcript is resent every turn, so cost grew with length. Once the chat passes **12 turns**, the oldest turns are folded into a single running "Story so far" recap (kept as the leading message) and dropped; the most recent **5 turns** stay verbatim. The resent transcript — and the per-turn token cost — stops growing.
- Re-compaction **compresses further**: the prior recap is fed back into the summariser along with the newly-aged turns and rewritten into one merged recap (older events get progressively more compressed), so there is always exactly one bounded recap, not an ever-growing append.
- The recap is written by **Haiku** (cheap) regardless of the DM model, in a separate call fired after a turn finishes — idle-only, never blocks input.
- The cut is taken on a clean turn boundary (detected robustly, since `stripStaleState` removes the state marker from older turns) so no `tool_use` / `tool_result` pair is ever orphaned. An async guard discards the result if the transcript changed mid-summary and retries next turn.
- Why 5 verbatim is safe: the authoritative game state (HP, positions, conditions) is resent fresh every turn regardless, so the DM never loses mechanical state — verbatim history only preserves recent conversational wording.

**Readable "Story so far" panel**
- A collapsed `<details>` in the AI DM section shows the current recap (previously invisible). Shows a hint until the first compaction, then the recap text; updates on compaction and restores from autosave/cloud. Display-only.

## Notes
- No build step, no new dependencies — plain vanilla JS/HTML/CSS, IIFE style unchanged. The recap rides in `aiMessages`, so it persists through autosave and the cloud `play_sessions.state` like the rest of the transcript.
- Verified in headless Chromium (Anthropic transport stubbed): 17 turns → one Haiku summary → transcript compacted to recap + a bounded verbatim window, DM continues answering on the compacted history with no error; recap panel shows empty → populated → restored across reload.
- Nothing goes live until this merges to `master` (which triggers the Pages deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiSD4yoNe89PqnHGMif5by)_