### PR TITLE
Add live token + cost tracking for the AI DM chat

### DIFF
--- a/ai-client.js
+++ b/ai-client.js
@@ -23,19 +23,89 @@
 
   var cfg = { mode: 'direct', endpoint: ANTHROPIC_URL };
 
-  // ---- Usage tracking (measurement, no behaviour change) ----
-  // Running tally for the session so the effect of caching/stripping is
-  // visible in the console. Read live via AIClient.sessionUsage.
+  // ---- Usage tracking (tokens + running cost of the AI DM chat) ----
+  // Running tally for the whole session: how many tokens we've SENT to Claude
+  // (input, incl. cached) and how many it has WRITTEN back (output). Read live
+  // via getUsage(); subscribe via onUsage() to drive a UI; the Play page rides
+  // it in the session snapshot so the count survives a reload.
   var sessionUsage = { calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  var usageSubscribers = [];
 
-  // Rough USD estimate at the default model's (claude-opus-4-8) list price:
-  // input $5/M, output $25/M, cache read $0.5/M, cache write (5m) $6.25/M.
-  function estCost(u) {
-    return ((u.input || 0) * 5 + (u.output || 0) * 25 +
-            (u.cacheRead || 0) * 0.5 + (u.cacheWrite || 0) * 6.25) / 1e6;
+  // Per-model list prices, USD per 1M tokens:
+  //   [ input, output, cacheRead (0.1x), cacheWrite 5m (1.25x) ].
+  // Matched by substring on the model id; unknown models fall back to Opus.
+  var PRICING = [
+    { match: 'fable',  rate: [10, 50, 1.0, 12.5] },
+    { match: 'mythos', rate: [10, 50, 1.0, 12.5] },
+    { match: 'haiku',  rate: [1, 5, 0.1, 1.25] },
+    { match: 'sonnet', rate: [3, 15, 0.3, 3.75] },
+    { match: 'opus',   rate: [5, 25, 0.5, 6.25] }
+  ];
+  var DEFAULT_RATE = [5, 25, 0.5, 6.25]; // Opus 4.8
+
+  function rateFor(model) {
+    var m = (model || getModel() || '').toLowerCase();
+    for (var i = 0; i < PRICING.length; i++) {
+      if (m.indexOf(PRICING[i].match) !== -1) return PRICING[i].rate;
+    }
+    return DEFAULT_RATE;
   }
 
-  function trackUsage(u) {
+  // USD estimate for a usage tally at the given model's list price.
+  function estCost(u, model) {
+    var r = rateFor(model);
+    return ((u.input || 0) * r[0] + (u.output || 0) * r[1] +
+            (u.cacheRead || 0) * r[2] + (u.cacheWrite || 0) * r[3]) / 1e6;
+  }
+
+  // A copy of the running tally, with derived totals and cost baked in.
+  function getUsage() {
+    var u = {
+      calls: sessionUsage.calls,
+      input: sessionUsage.input,
+      output: sessionUsage.output,
+      cacheRead: sessionUsage.cacheRead,
+      cacheWrite: sessionUsage.cacheWrite
+    };
+    // Total tokens we sent up (fresh input + everything served from / written
+    // to cache is still input we delivered for reading).
+    u.totalIn = u.input + u.cacheRead + u.cacheWrite;
+    u.totalOut = u.output;
+    u.cost = estCost(u);
+    return u;
+  }
+
+  // Restore the tally from a persisted snapshot (Play autosave / cloud save).
+  function setUsage(u) {
+    u = u || {};
+    sessionUsage.calls = u.calls || 0;
+    sessionUsage.input = u.input || 0;
+    sessionUsage.output = u.output || 0;
+    sessionUsage.cacheRead = u.cacheRead || 0;
+    sessionUsage.cacheWrite = u.cacheWrite || 0;
+    notifyUsage();
+  }
+
+  // Subscribe to usage updates. cb(session) is called after every API call
+  // and whenever the tally is reset/restored. Returns an unsubscribe fn.
+  function onUsage(cb) {
+    if (typeof cb !== 'function') return function () {};
+    usageSubscribers.push(cb);
+    try { cb(getUsage()); } catch (e) { /* ignore */ }
+    return function () {
+      var i = usageSubscribers.indexOf(cb);
+      if (i !== -1) usageSubscribers.splice(i, 1);
+    };
+  }
+
+  function notifyUsage() {
+    var snap = getUsage();
+    for (var i = 0; i < usageSubscribers.length; i++) {
+      try { usageSubscribers[i](snap); } catch (e) { /* ignore */ }
+    }
+  }
+
+  function trackUsage(u, model) {
     if (!u) return;
     var call = {
       input: u.input_tokens || 0,
@@ -51,15 +121,17 @@
     try {
       console.log('[AI usage] call in=' + call.input + ' out=' + call.output +
         ' cacheRead=' + call.cacheRead + ' cacheWrite=' + call.cacheWrite +
-        ' ~$' + estCost(call).toFixed(4) +
+        ' ~$' + estCost(call, model).toFixed(4) +
         '  | session: ' + sessionUsage.calls + ' calls, ~$' +
-        estCost(sessionUsage).toFixed(3));
+        estCost(sessionUsage, model).toFixed(3));
     } catch (e) { /* console unavailable */ }
+    notifyUsage();
   }
 
   function resetUsage() {
     sessionUsage.calls = sessionUsage.input = sessionUsage.output =
       sessionUsage.cacheRead = sessionUsage.cacheWrite = 0;
+    notifyUsage();
   }
 
   function configure(o) {
@@ -77,8 +149,9 @@
   // req: { system, messages, tools?, model?, max_tokens? }
   // Returns the parsed Anthropic Messages response object.
   function complete(req) {
+    var model = req.model || getModel();
     var body = {
-      model: req.model || getModel(),
+      model: model,
       max_tokens: req.max_tokens || 1024,
       messages: req.messages
     };
@@ -107,7 +180,7 @@
           throw new Error('Claude API ' + res.status + ': ' + msg);
         }
         var parsed = JSON.parse(txt);
-        trackUsage(parsed.usage);
+        trackUsage(parsed.usage, model);
         return parsed;
       });
     });
@@ -134,6 +207,7 @@
     getKey: getKey, setKey: setKey, hasKey: hasKey,
     getModel: getModel, setModel: setModel, DEFAULT_MODEL: DEFAULT_MODEL,
     complete: complete, textOf: textOf, toolCallsOf: toolCallsOf,
-    sessionUsage: sessionUsage, resetUsage: resetUsage
+    sessionUsage: sessionUsage, resetUsage: resetUsage,
+    getUsage: getUsage, setUsage: setUsage, onUsage: onUsage, estCost: estCost
   };
 })();

--- a/play.html
+++ b/play.html
@@ -211,6 +211,8 @@
                     <h2 class="ai__title">AI Dungeon Master</h2>
                     <span id="ai-key-state" class="ai__keystate" hidden>✓ key saved</span>
                 </div>
+                <button type="button" id="ai-usage" class="ai__usage" hidden
+                        title="Tokens exchanged with Claude this session and the estimated cost so far. Click for a breakdown."></button>
             </div>
 
             <details class="ai__settings" id="ai-settings">

--- a/play.js
+++ b/play.js
@@ -80,6 +80,7 @@
       scene: state.scene,
       chatLog: state.chatLog,
       aiMessages: aiMessages,
+      aiUsage: (window.AIClient && window.AIClient.getUsage) ? window.AIClient.getUsage() : null,
       map: window.Battlemap ? window.Battlemap.getMap() : null
     };
   }
@@ -117,6 +118,7 @@
     state.scene = data.scene || null;
     state.chatLog = data.chatLog || [];
     aiMessages = data.aiMessages || [];
+    if (window.AIClient && window.AIClient.setUsage) window.AIClient.setUsage(data.aiUsage || {});
     if (window.Battlemap) window.Battlemap.setMap(data.map || null);
 
     renderAll();
@@ -957,6 +959,50 @@
 
   function aiStatus(text) { if (el.aiStatus) el.aiStatus.textContent = text || ''; }
 
+  // Compact token count: 0, 940, 12.3k, 1.4M.
+  function fmtTokens(n) {
+    n = n || 0;
+    if (n < 1000) return String(n);
+    if (n < 1e6) return (n / 1e3).toFixed(n < 10000 ? 1 : 0) + 'k';
+    return (n / 1e6).toFixed(1) + 'M';
+  }
+  // USD: <$0.01 shown as "<$0.01", else 2–3 decimals.
+  function fmtCost(c) {
+    c = c || 0;
+    if (c > 0 && c < 0.01) return '<$0.01';
+    return '$' + (c < 1 ? c.toFixed(3) : c.toFixed(2));
+  }
+  // The little token/cost readout in the AI panel header.
+  function renderUsage(u) {
+    if (!el.aiUsage) return;
+    u = u || (window.AIClient && window.AIClient.getUsage ? window.AIClient.getUsage() : null);
+    if (!u || !u.calls) { el.aiUsage.hidden = true; return; }
+    el.aiUsage.hidden = false;
+    el.aiUsage.textContent = '↑ ' + fmtTokens(u.totalIn) + ' · ↓ ' +
+      fmtTokens(u.totalOut) + ' · ~' + fmtCost(u.cost);
+  }
+  // Full breakdown on click/tap.
+  function showUsageBreakdown() {
+    if (!window.AIClient || !window.AIClient.getUsage) return;
+    var u = window.AIClient.getUsage();
+    var cached = u.cacheRead + u.cacheWrite;
+    var lines = [
+      'AI Dungeon Master — usage this session',
+      '',
+      'Requests to Claude: ' + u.calls,
+      'Tokens sent (read by Claude): ' + u.totalIn.toLocaleString(),
+      '  · fresh input: ' + u.input.toLocaleString(),
+      '  · from/to cache: ' + cached.toLocaleString(),
+      'Tokens written back (Claude → us): ' + u.totalOut.toLocaleString(),
+      '',
+      'Estimated cost so far: ~' + fmtCost(u.cost) +
+        ' (' + (window.AIClient.getModel ? window.AIClient.getModel() : 'model') + ' list price)',
+      '',
+      'Reset the chat to start the count over.'
+    ];
+    alert(lines.join('\n'));
+  }
+
   function appendChatBubble(role, text, opts) {
     if (!text) return;
     opts = opts || {};
@@ -1510,6 +1556,7 @@
     aiMessages = [];
     state.chatLog = [];
     if (window.Voice) Voice.stop();
+    if (window.AIClient && window.AIClient.resetUsage) window.AIClient.resetUsage();
     chatRenderStart = 0;
     if (el.aiOutput) el.aiOutput.innerHTML = '';
     renderRecapPanel();
@@ -1642,6 +1689,7 @@
     el.aiInput       = document.querySelector('#ai-input');
     el.aiSendBtn     = document.querySelector('.btn-ai-send');
     el.aiStatus      = document.querySelector('#ai-status');
+    el.aiUsage       = document.querySelector('#ai-usage');
     el.aiOutput      = document.querySelector('#ai-output');
     el.voiceKey      = document.querySelector('#voice-key');
     el.voicePreset   = document.querySelector('#voice-preset');
@@ -1656,6 +1704,8 @@
     syncModelSelect();
     updateKeyState();
     renderRecapPanel();
+    if (window.AIClient.onUsage) window.AIClient.onUsage(renderUsage);
+    if (el.aiUsage) el.aiUsage.addEventListener('click', showUsageBreakdown);
     el.aiModel.addEventListener('change', function () {
       var custom = el.aiModel.value === '__custom__';
       if (el.aiModelCustomField) el.aiModelCustomField.hidden = !custom;

--- a/style.css
+++ b/style.css
@@ -1229,6 +1229,12 @@ button:disabled { opacity: .4; cursor: not-allowed; box-shadow: none; }
     font-size: 12px; color: #27ae60; background: rgba(39,174,96,.12);
     border: 1px solid rgba(39,174,96,.35); border-radius: 999px; padding: 2px 9px; white-space: nowrap;
 }
+.ai__usage {
+    font-family: inherit; font-size: 12px; color: #9aa3b2; background: #12141a;
+    border: 1px solid #2c3140; border-radius: 999px; padding: 3px 11px; white-space: nowrap;
+    cursor: pointer; flex-shrink: 0;
+}
+.ai__usage:hover { color: #e6e6e6; border-color: #3b4150; }
 /* Settings is a native <details> so the toggle can't silently break */
 .ai__settings {
     background: #12141a; border: 1px solid #2c3140; border-radius: 8px; margin-bottom: 12px;


### PR DESCRIPTION
Shows how many tokens the AI Dungeon Master has exchanged with Claude this session and the running cost so far, right in the AI panel header.

## What you get

A small pill in the **AI Dungeon Master** panel header:

```
↑ 25k  ·  ↓ 3.0k  ·  ~$0.135
```

- **↑** — tokens delivered *for reading* (fresh input + cache read/write we send up to Claude)
- **↓** — tokens Claude has *written back* to us (output)
- **~$** — estimated running cost of the chat/adventure so far

Click the pill for a full breakdown: number of requests, fresh vs. cached input, output, and which model's list price the estimate uses.

## Changes

- **`ai-client.js`** — the session already tallied usage to the console; extended it with per-model list pricing (Opus / Sonnet / Haiku / Fable, fallback to Opus 4.8), a model-aware `estCost`, `getUsage`/`setUsage`, and an `onUsage` subscription so the UI updates after every call.
- **`play.js`** — subscribes the header readout to usage updates, persists the tally in the session snapshot (rides local autosave + cloud saves, survives a reload), and resets it when the chat is reset.
- **`play.html` / `style.css`** — the readout pill in the AI head, styled to match the dark palette.

## Notes

- Cost is an **estimate at list price** — with BYOK the user's own key is billed. It counts the AI DM chat only; the optional ElevenLabs voice layer is a separate service and is not tallied here.
- Purely additive and local-first: no new network calls, degrades gracefully when no key is set.

## Testing

- `node --check` on both JS files.
- Standalone check of the pricing/usage math (Opus tally of 10k in / 4k out / 20k cache-read / 5k cache-write → ~$0.19).
- Browser smoke test (Chromium): readout hidden until the first request, then renders `↑ 25k · ↓ 3.0k · ~$0.135` on a simulated usage update, no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfRnUsQs96Q45MxcqzMjnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfRnUsQs96Q45MxcqzMjnx)_