### PR TITLE
Add optional, self-contained Gemini provider for the AI DM

### DIFF
--- a/ai-client.js
+++ b/ai-client.js
@@ -23,6 +23,19 @@
 
   var cfg = { mode: 'direct', endpoint: ANTHROPIC_URL };
 
+  // ---- Provider registry (ADDITIVE — Anthropic is the built-in default) ----
+  // Optional extra providers (e.g. Gemini) register themselves here via
+  // registerProvider(). They translate to/from the canonical Anthropic-shaped
+  // response so nothing downstream (play.js, ai-dm.js) changes.
+  // TO REMOVE GEMINI (or any add-on provider): delete its file (ai-gemini.js)
+  // and its <script> tag. This registry then goes inert and the Anthropic path
+  // below runs exactly as before — no other edits needed.
+  var providers = {};
+  var PROVIDER_LS = 'diceAndMonsters.aiProvider';
+  function registerProvider(name, fn) { if (name && typeof fn === 'function') providers[name] = fn; }
+  function getProvider() { try { return window.localStorage.getItem(PROVIDER_LS) || 'anthropic'; } catch (e) { return 'anthropic'; } }
+  function setProvider(p) { try { window.localStorage.setItem(PROVIDER_LS, p || 'anthropic'); } catch (e) { /* ignore */ } }
+
   // ---- Usage tracking (tokens + running cost of the AI DM chat) ----
   // Running tally for the whole session: how many tokens we've SENT to Claude
   // (input, incl. cached) and how many it has WRITTEN back (output). Read live
@@ -39,7 +52,13 @@
     { match: 'mythos', rate: [10, 50, 1.0, 12.5] },
     { match: 'haiku',  rate: [1, 5, 0.1, 1.25] },
     { match: 'sonnet', rate: [3, 15, 0.3, 3.75] },
-    { match: 'opus',   rate: [5, 25, 0.5, 6.25] }
+    { match: 'opus',   rate: [5, 25, 0.5, 6.25] },
+    // Google Gemini — PLACEHOLDER rates (USD per 1M). VERIFY current pricing at
+    // ai.google.dev/pricing before trusting the cost readout. Cache-write is 0
+    // (Gemini bills context caching differently). Safe to delete with Gemini.
+    { match: 'flash-lite', rate: [0.10, 0.40, 0.025, 0] },
+    { match: 'flash',      rate: [0.30, 2.50, 0.075, 0] },
+    { match: 'gemini',     rate: [0.30, 2.50, 0.075, 0] }
   ];
   var DEFAULT_RATE = [5, 25, 0.5, 6.25]; // Opus 4.8
 
@@ -150,6 +169,23 @@
   // Returns the parsed Anthropic Messages response object.
   function complete(req) {
     var model = req.model || getModel();
+
+    // Route to a registered add-on provider when one is active. It returns a
+    // canonical (Anthropic-shaped) response; we track usage against the model
+    // it reports so the cost estimate uses that provider's rates.
+    var provider = req.provider || getProvider();
+    if (provider && provider !== 'anthropic') {
+      if (!providers[provider]) {
+        // Provider selected but its file was removed → fall back to Anthropic.
+        try { console.warn('[AI] provider "' + provider + '" not loaded; using Anthropic.'); } catch (e) {}
+      } else {
+        return Promise.resolve(providers[provider](req, model)).then(function (canonical) {
+          trackUsage(canonical.usage, canonical.model || model);
+          return canonical;
+        });
+      }
+    }
+
     var body = {
       model: model,
       max_tokens: req.max_tokens || 1024,
@@ -208,6 +244,8 @@
     getModel: getModel, setModel: setModel, DEFAULT_MODEL: DEFAULT_MODEL,
     complete: complete, textOf: textOf, toolCallsOf: toolCallsOf,
     sessionUsage: sessionUsage, resetUsage: resetUsage,
-    getUsage: getUsage, setUsage: setUsage, onUsage: onUsage, estCost: estCost
+    getUsage: getUsage, setUsage: setUsage, onUsage: onUsage, estCost: estCost,
+    // Provider registry (add-on providers like Gemini plug in here).
+    registerProvider: registerProvider, getProvider: getProvider, setProvider: setProvider
   };
 })();

--- a/ai-gemini.js
+++ b/ai-gemini.js
@@ -1,0 +1,198 @@
+/* ============================================================
+   Dice & Monsters — Gemini provider (OPTIONAL, self-contained)
+   ------------------------------------------------------------
+   Lets the AI DM run on Google Gemini instead of Claude. It plugs
+   into AIClient via registerProvider('gemini', …) and translates
+   to/from the canonical (Anthropic-shaped) response, so play.js,
+   ai-dm.js and ai-player.js don't change.
+
+   ▶ TO DELETE GEMINI ENTIRELY:
+       1. Delete this file (ai-gemini.js).
+       2. Remove its <script> tag from play.html (and any other page).
+       3. If you set the provider, reset it:
+            localStorage.removeItem('diceAndMonsters.aiProvider');
+     That's it — the provider registry in ai-client.js goes inert and
+     the app runs on Claude exactly as before. No other edits needed.
+
+   ▶ TO TEST (BYOK — key stays in YOUR browser only, never the repo):
+       localStorage.setItem('diceAndMonsters.geminiKey', '<your key>');
+       localStorage.setItem('diceAndMonsters.geminiModel', 'gemini-flash-latest');
+       localStorage.setItem('diceAndMonsters.aiProvider', 'gemini');
+     then reload play.html. Switch back with aiProvider = 'anthropic'.
+
+   NOTE: shipping YOUR key to other users' browsers is unsafe — for a
+   real free tier, point ENDPOINT at a relay (Supabase edge function)
+   that holds the key server-side. See cfg.endpoint below.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  var KEY_LS   = 'diceAndMonsters.geminiKey';
+  var MODEL_LS = 'diceAndMonsters.geminiModel';
+  var DEFAULT_MODEL = 'gemini-flash-latest';   // change freely; verify the id at ai.google.dev
+
+  var cfg = {
+    // Direct browser → Google. For a shared free tier, replace this with a
+    // relay URL and have the relay inject the key (then getKey() can be empty).
+    endpoint: function (model, key) {
+      return 'https://generativelanguage.googleapis.com/v1beta/models/' +
+        encodeURIComponent(model) + ':generateContent?key=' + encodeURIComponent(key);
+    }
+  };
+
+  function getKey()   { try { return window.localStorage.getItem(KEY_LS) || ''; } catch (e) { return ''; } }
+  function setKey(k)  { try { window.localStorage.setItem(KEY_LS, k || ''); } catch (e) { /* ignore */ } }
+  function hasKey()   { return !!getKey(); }
+  function getModel() { try { return window.localStorage.getItem(MODEL_LS) || DEFAULT_MODEL; } catch (e) { return DEFAULT_MODEL; } }
+  function setModel(m){ try { window.localStorage.setItem(MODEL_LS, m || DEFAULT_MODEL); } catch (e) { /* ignore */ } }
+
+  // ---- helpers -------------------------------------------------------------
+
+  function asText(x) {
+    if (x == null) return '';
+    if (typeof x === 'string') return x;
+    // tool_result content may be a string or an array of {type:'text',text}.
+    if (Array.isArray(x)) {
+      return x.map(function (b) { return (b && b.text) ? b.text : ''; }).join('\n');
+    }
+    return String(x);
+  }
+
+  // system may be a plain string or [{type:'text',text,cache_control?}] (we
+  // ignore cache_control — Gemini has its own caching).
+  function sysText(system) {
+    if (!system) return '';
+    if (typeof system === 'string') return system;
+    if (Array.isArray(system)) {
+      return system.map(function (b) { return (b && b.text) ? b.text : ''; }).join('\n\n');
+    }
+    return String(system);
+  }
+
+  // Anthropic tool  →  Gemini functionDeclaration (input_schema IS JSON Schema).
+  function toGeminiTool(t) {
+    return { name: t.name, description: t.description || '', parameters: t.input_schema || { type: 'object', properties: {} } };
+  }
+
+  // Canonical message array  →  Gemini `contents`.
+  // Roles: user/assistant → user/model. tool_use → functionCall (model turn);
+  // tool_result → functionResponse (user turn). Gemini keys functionResponse by
+  // NAME, not id, so we map each tool_use id → name as we walk the transcript.
+  function toGeminiContents(messages) {
+    var idToName = {};
+    var out = [];
+    (messages || []).forEach(function (m) {
+      var role = (m.role === 'assistant') ? 'model' : 'user';
+      var parts = [];
+      var content = m.content;
+
+      if (typeof content === 'string') {
+        if (content) parts.push({ text: content });
+      } else if (Array.isArray(content)) {
+        content.forEach(function (b) {
+          if (!b) return;
+          if (b.type === 'text') {
+            if (b.text) parts.push({ text: b.text });
+          } else if (b.type === 'tool_use') {
+            idToName[b.id] = b.name;
+            parts.push({ functionCall: { name: b.name, args: b.input || {} } });
+          } else if (b.type === 'tool_result') {
+            var name = idToName[b.tool_use_id] || b.tool_use_id || 'tool';
+            var resp = { content: asText(b.content) };
+            if (b.is_error) resp.is_error = true;
+            parts.push({ functionResponse: { name: name, response: resp } });
+          }
+        });
+      }
+
+      if (parts.length) out.push({ role: role, parts: parts });
+    });
+    return out;
+  }
+
+  // Gemini response  →  canonical (Anthropic-shaped) response.
+  function fromGemini(res, model) {
+    if (res && res.error) {
+      throw new Error('Gemini API: ' + (res.error.message || JSON.stringify(res.error)));
+    }
+    var cand = (res && res.candidates && res.candidates[0]) || {};
+    var parts = (cand.content && cand.content.parts) || [];
+    var content = [], sawTool = false, n = 0;
+
+    parts.forEach(function (p) {
+      if (p == null) return;
+      if (typeof p.text === 'string' && p.text) {
+        content.push({ type: 'text', text: p.text });
+      } else if (p.functionCall) {
+        sawTool = true;
+        content.push({
+          type: 'tool_use',
+          id: 'g' + (n++),
+          name: p.functionCall.name,
+          input: p.functionCall.args || {}
+        });
+      }
+    });
+
+    var u = res.usageMetadata || {};
+    return {
+      model: model,
+      content: content,
+      stop_reason: sawTool ? 'tool_use' : 'end_turn',
+      usage: {
+        input_tokens:  u.promptTokenCount || 0,
+        output_tokens: u.candidatesTokenCount || 0,
+        cache_read_input_tokens: u.cachedContentTokenCount || 0,
+        cache_creation_input_tokens: 0
+      }
+    };
+  }
+
+  // ---- the provider entry point (matches registerProvider's contract) ------
+  // req: canonical { system, messages, tools?, model?, max_tokens? }
+  function complete(req, passedModel) {
+    // Prefer an explicitly-passed gemini model; otherwise our stored default.
+    var model = (passedModel && /gemini/i.test(passedModel)) ? passedModel : getModel();
+    var key = getKey();
+    if (!key) return Promise.reject(new Error('No Gemini API key set. Add it in localStorage (diceAndMonsters.geminiKey).'));
+
+    var body = {
+      contents: toGeminiContents(req.messages),
+      generationConfig: { maxOutputTokens: req.max_tokens || 1024 }
+    };
+    var sys = sysText(req.system);
+    if (sys) body.system_instruction = { parts: [{ text: sys }] };
+    if (req.tools && req.tools.length) {
+      body.tools = [{ function_declarations: req.tools.map(toGeminiTool) }];
+    }
+
+    return fetch(cfg.endpoint(model, key), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body)
+    }).then(function (res) {
+      return res.text().then(function (txt) {
+        var parsed;
+        try { parsed = JSON.parse(txt); } catch (e) { parsed = null; }
+        if (!res.ok) {
+          var msg = txt;
+          if (parsed && parsed.error && parsed.error.message) msg = parsed.error.message;
+          throw new Error('Gemini API ' + res.status + ': ' + msg);
+        }
+        return fromGemini(parsed, model);
+      });
+    });
+  }
+
+  // Register with AIClient if present (this file loads AFTER ai-client.js).
+  if (window.AIClient && window.AIClient.registerProvider) {
+    window.AIClient.registerProvider('gemini', complete);
+  }
+
+  // One global, for optional settings UI / console use.
+  window.GeminiProvider = {
+    complete: complete,
+    getKey: getKey, setKey: setKey, hasKey: hasKey,
+    getModel: getModel, setModel: setModel, DEFAULT_MODEL: DEFAULT_MODEL
+  };
+})();

--- a/play.html
+++ b/play.html
@@ -352,6 +352,7 @@
         <script src="visibility.js"></script>
         <script src="ai-context.js"></script>
         <script src="ai-client.js"></script>
+        <script src="ai-gemini.js"></script>
         <script src="ai-dm.js"></script>
         <script src="ai-player.js"></script>
         <script src="voice.js"></script>


### PR DESCRIPTION
Lets the AI DM run on Google Gemini as an alternative to Claude, built so it can be removed cleanly if it doesn't pan out. The design keeps Anthropic's response shape as the app's **canonical format** and translates per provider, so `play.js` / `ai-dm.js` / `ai-player.js` are unchanged.

## Changes

- **`ai-client.js`** — an **inert provider registry** (`registerProvider` / `getProvider` / `setProvider`). `complete()` routes to a registered non-Anthropic provider and falls back to the untouched Anthropic path when none is active (or its file is absent). Placeholder Gemini/Flash rows added to the pricing table, clearly marked to verify.
- **`ai-gemini.js`** (new) — self-contained transport. Translates the canonical request → Gemini `generateContent` (`system_instruction`; `contents` with user/model roles; `functionCall`/`functionResponse` for `tool_use`/`tool_result`; tools → `functionDeclarations`) and normalizes the response back to the Anthropic shape (content blocks, `stop_reason`, `usage`). BYOK key + model live in `localStorage` only — never committed; the endpoint is swappable for a relay later.
- **`play.html`** — loads `ai-gemini.js` after `ai-client.js`.

## Safety & removal

- **No secrets in the repo.** The Gemini key is BYOK in `localStorage`, exactly like the existing Anthropic key. A shared free tier would instead point the endpoint at a relay that holds the key server-side.
- **Removal is one file + one `<script>` tag + clearing the `aiProvider` key.** The registry then goes inert and the app runs on Claude exactly as before. Full instructions are documented at the top of `ai-gemini.js`.

## Verification

- `node --check` passes on both JS files.
- The Anthropic path is the default and is unchanged (the provider branch only runs when `aiProvider !== 'anthropic'` and a provider is registered).
- Translation verified with a stubbed fetch: `tool_use`/`tool_result` round-trips, the `tool_use_id` → function-name mapping, and usage normalization all hold, and the canonical response matches what the existing chat loop consumes.

⚠️ The Gemini pricing rows are placeholders — verify current Google rates before trusting the cost readout for Gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2LiJyhSfgex32Xb9dRyUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2LiJyhSfgex32Xb9dRyUZ)_